### PR TITLE
Core modules + CLI plumbing (Tasks 7-14)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,4 +3,4 @@ max-line-length = 100
 extend-ignore = E203, W503
 exclude = .git,__pycache__,build,dist,.venv
 per-file-ignores =
-    tests/*:S101
+    tests/*:S101,F401

--- a/.flake8
+++ b/.flake8
@@ -3,4 +3,4 @@ max-line-length = 100
 extend-ignore = E203, W503
 exclude = .git,__pycache__,build,dist,.venv
 per-file-ignores =
-    tests/*:S101,F401
+    tests/*:S101

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,17 +32,12 @@ jobs:
       - run: uv sync
       - run: uv run pytest -n auto --cov=shushu --cov-report=term -m "not integration"
 
-  integration:
-    runs-on: ubuntu-latest
-    # Skip until tests/integration/ exists (planned: Task 26 — admin setuid-fork
-    # handoff tests that need real useradd/userdel inside a disposable container).
-    if: hashFiles('tests/integration/**') != ''
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-      - name: Build integration image
-        run: docker build -t shushu-int -f .github/workflows/Dockerfile.integration .
-      - name: Run integration tests inside container
-        run: docker run --rm -e SHUSHU_DOCKER=1 shushu-int uv run pytest tests/integration -v -m integration
+  # Integration job re-introduced in Task 26 once tests/integration/ exists
+  # (admin setuid-fork handoff tests need real useradd/userdel and run inside
+  # the disposable Docker image at .github/workflows/Dockerfile.integration).
+  # Earlier attempt used `if: hashFiles(...) != ''` to gate it, which GitHub
+  # rejected at workflow-validation time and prevented the entire `tests`
+  # workflow from starting (visible as a 0s "workflow file issue" failure).
 
   version-check:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,24 @@ with merged PRs per the per-PR version bump discipline documented in
 
 ## [Unreleased]
 
-- (nothing yet — v0.3.0 cut; next bump on the following PR)
+- (nothing yet — v0.3.1 cut; next bump on the following PR)
+
+## [0.3.1] — 2026-04-24
+
+### Fixed
+
+- **CI tests pipeline running again.** The `tests` workflow had been silently failing at workflow-validation time on every run since PR #2, because the `if: hashFiles('tests/integration/**') != ''` gate added on the `integration` job is rejected by GitHub Actions before any job starts (visible as a 0s "workflow file issue"). Removed the `integration` job entirely; it returns in Task 26 once `tests/integration/` exists. lint / unit / version-check now actually run on every PR.
+- `store.load()` TOCTOU: dropped the `paths.file.exists()` precheck outside the lock; existence is now decided inside `_load_raw_unlocked()` under `LOCK_SH`. (Copilot, Qodo)
+- `_json_to_record()` strict bool check on `hidden`: `bool("false")` is truthy and previously coerced corrupt stores into "hidden" silently. Now raises `StateError`. (Copilot)
+- `_load_raw_unlocked()` validates the `secrets` field is a list and catches `TypeError` from malformed records, so non-list / non-dict input surfaces as `StateError` instead of bypassing the schema-enforced contract. (Copilot)
+- `fs.ensure_store_dir()` lockfile creation no longer races: dropped `O_EXCL` and the `exists()` precheck so concurrent first-run callers don't crash with `FileExistsError`. (Qodo)
+- `cli/_output.py::emit_error` now defaults to `sys.stdout` when `json_mode=True` (and `sys.stderr` otherwise). The `--json` contract — one JSON object on stdout for both success and error responses — was previously broken for errors. (Copilot, Qodo)
+- `tests/unit/test_users.py` now compares against `os.geteuid()` to match `users.current()`'s implementation; previously the test would have failed under any `setuid`/sudo scenario where `uid != euid`. (Copilot)
+- `tests/unit/test_privilege.py`: renamed two test functions whose names contained uppercase `SUDO_USER` to satisfy `python:S1542` (snake_case convention). (SonarCloud)
+
+### Tests
+
+- Added regression tests for non-list `secrets`, non-bool `hidden`, and `emit_error` default-stream behavior in both modes.
 
 ## [0.3.0] — 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,27 @@ with merged PRs per the per-PR version bump discipline documented in
 
 ## [Unreleased]
 
-- (nothing yet — v0.2.0 cut; next bump on the following PR)
+- (nothing yet — v0.3.0 cut; next bump on the following PR)
+
+## [0.3.0] — 2026-04-24
+
+### Added
+
+- `shushu.fs` — paths, fcntl advisory locking (shared/exclusive), atomic write-temp-fsync-rename. Respects `SHUSHU_HOME` env override for tests.
+- `shushu.alerts` — UTC-based classification of a record's `alert_at` as `ok` / `alerting` (≤30 days) / `expired`.
+- `shushu.generate` — random hex/base64 secrets via `secrets.token_bytes` (32-byte default).
+- `shushu.users` — `pwd`-backed `UserInfo` dataclass + `current` / `resolve` / `all_users`.
+- `shushu.privilege` — `PrivilegeError`, `require_root`, `sudo_invoker`, `resolve_shushu_path`, and `run_as_user` setuid-fork helper for admin handoff.
+- `shushu.store` — schema-enforced JSON CRUD: `SecretRecord` / `StoreData` dataclasses, `load` / `set_secret` / `update_metadata` / `get_value` / `get_record` / `delete` / `list_names`, typed errors (`ValidationError`, `NotFoundError`, `HiddenError`, `StateError`). Mutations run under a single `LOCK_EX` for the full read-mutate-atomic-write cycle.
+- `shushu.cli._errors` — `ShushuError` + exit-code constants.
+- `shushu.cli._output` — `emit_result` / `emit_error` / `emit_warning` with text-vs-JSON discipline.
+- CLI parser skeleton: `shushu --help` lists all 12 verbs (doctor, learn, explain, overview, set, show, get, env, run, generate, list, delete); dispatch routes to stub handlers that raise `NotImplementedError` (replaced by Tasks 15-25).
+
+### Security / correctness
+
+- Error classes (`PrivilegeError`, `ShushuError`) pass only `message` to `super().__init__()` so `str(exc)` stays human-readable. `remediation` lives as an attribute. B042 silenced locally with a rationale comment.
+- `store.py` rejects `schema_version` that is missing, non-integer, or wrong-valued with distinct error messages instead of a single misleading one.
+- `store.py` datetime parse errors name the expected canonical wire format (`YYYY-MM-DDTHH:MM:SSZ`) instead of echoing the cryptic `strptime` traceback.
 
 ## [0.2.0] — 2026-04-24
 

--- a/docs/superpowers/plans/2026-04-24-shushu-secrets-cli-v1.md
+++ b/docs/superpowers/plans/2026-04-24-shushu-secrets-cli-v1.md
@@ -444,9 +444,6 @@ from __future__ import annotations
 import json
 import os
 import stat
-from pathlib import Path
-
-import pytest
 
 from shushu import fs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shushu"
-version = "0.2.0"
+version = "0.3.0"
 description = "shushu CLI"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shushu"
-version = "0.3.0"
+version = "0.3.1"
 description = "shushu CLI"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/shushu/alerts.py
+++ b/src/shushu/alerts.py
@@ -1,0 +1,40 @@
+"""Alert-date classification for shushu records.
+
+`alert_at` is a date (no time). We compare against today's UTC date.
+Classification categories:
+- "ok"        — no alert_at, or alert_at is >30 days in the future
+- "alerting"  — alert_at is in the next 30 days (inclusive of today)
+- "expired"   — alert_at is in the past
+
+This module is pure: no I/O, no store knowledge.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Literal
+
+AlertState = Literal["ok", "alerting", "expired"]
+
+ALERT_WINDOW_DAYS = 30
+
+
+def today_utc() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def classify(alert_at: date | None, today: date | None = None) -> AlertState:
+    if alert_at is None:
+        return "ok"
+    today = today or today_utc()
+    if alert_at < today:
+        return "expired"
+    if (alert_at - today).days <= ALERT_WINDOW_DAYS:
+        return "alerting"
+    return "ok"
+
+
+def parse_date(s: str | None) -> date | None:
+    if s is None or s == "":
+        return None
+    return date.fromisoformat(s)

--- a/src/shushu/cli/__init__.py
+++ b/src/shushu/cli/__init__.py
@@ -1,39 +1,214 @@
-"""shushu CLI entry point.
-
-This package will grow `_build_parser` + `_dispatch` + per-verb modules
-under `_commands/` as the spec is implemented. For now it preserves the
-scaffold's behaviour so the version test stays green.
-"""
+"""shushu CLI entry point: parser + dispatch + error routing."""
 
 from __future__ import annotations
 
 import argparse
+import sys
+import traceback
 from collections.abc import Sequence
 
-from shushu import __version__
+from shushu import __version__, privilege, store
+from shushu.cli import _output
+from shushu.cli._commands import (
+    delete,
+    doctor,
+    env,
+    explain,
+    generate,
+    get,
+    learn,
+    list_,
+    overview,
+    run,
+)
+from shushu.cli._commands import set as set_cmd
+from shushu.cli._commands import show
+from shushu.cli._errors import (
+    EXIT_INTERNAL,
+    EXIT_PRIVILEGE,
+    EXIT_STATE,
+    EXIT_SUCCESS,
+    EXIT_USER_ERROR,
+    ShushuError,
+)
 
 PROG = "shushu"
 
+_HANDLERS = {
+    "doctor": doctor.handle,
+    "overview": overview.handle,
+    "learn": learn.handle,
+    "explain": explain.handle,
+    "set": set_cmd.handle,
+    "show": show.handle,
+    "get": get.handle,
+    "env": env.handle,
+    "run": run.handle,
+    "generate": generate.handle,
+    "list": list_.handle,
+    "delete": delete.handle,
+}
+
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog=PROG,
-        description="shushu — agent-first per-OS-user secrets manager",
+    p = argparse.ArgumentParser(prog=PROG, description="shushu — agent-first secrets manager")
+    p.add_argument("--version", action="version", version=f"{PROG} {__version__}")
+    sub = p.add_subparsers(dest="cmd")
+
+    # globals
+    sub.add_parser("doctor", help="Store health / integrity checks").add_argument(
+        "--json", action="store_true"
     )
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=f"{PROG} {__version__}",
+    sub.add_parser("learn", help="Agent-authored self-teaching output").add_argument(
+        "--json", action="store_true"
     )
-    return parser
+    pe = sub.add_parser("explain", help="Explain a command or concept")
+    pe.add_argument("topic")
+
+    po = sub.add_parser("overview", help="Rich metadata snapshot")
+    po.add_argument("--json", action="store_true")
+    po.add_argument("--expired", action="store_true")
+    _add_admin_flags(po)
+
+    # secret verbs
+    ps = sub.add_parser("set", help="Create or update a secret")
+    ps.add_argument("name")
+    ps.add_argument("value", nargs="?")
+    ps.add_argument("--source")
+    ps.add_argument("--purpose")
+    ps.add_argument("--rotate-howto", dest="rotate_howto")
+    ps.add_argument("--alert-at", dest="alert_at")
+    ps.add_argument("--hidden", action="store_true")
+    ps.add_argument("--json", action="store_true")
+    _add_admin_flags(ps, all_users=False)
+
+    psh = sub.add_parser("show", help="Show metadata (never value)")
+    psh.add_argument("name")
+    psh.add_argument("--json", action="store_true")
+    _add_admin_flags(psh, all_users=False)
+
+    pg = sub.add_parser("get", help="Print value (refuses hidden)")
+    pg.add_argument("name")
+    pg.add_argument("--json", action="store_true")
+
+    pe2 = sub.add_parser("env", help="Emit shell export lines")
+    pe2.add_argument("names", nargs="+")
+
+    pr = sub.add_parser("run", help="Spawn a subprocess with injected secrets")
+    pr.add_argument("--inject", action="append", required=True, metavar="VAR=NAME")
+    pr.add_argument("cmd_and_args", nargs=argparse.REMAINDER)
+
+    pgn = sub.add_parser("generate", help="Create a random secret")
+    pgn.add_argument("name")
+    pgn.add_argument("--bytes", dest="nbytes", type=int, default=32)
+    pgn.add_argument("--encoding", choices=["hex", "base64"], default="hex")
+    pgn.add_argument("--source")
+    pgn.add_argument("--purpose")
+    pgn.add_argument("--rotate-howto", dest="rotate_howto")
+    pgn.add_argument("--alert-at", dest="alert_at")
+    pgn.add_argument("--hidden", action="store_true")
+    pgn.add_argument("--json", action="store_true")
+    _add_admin_flags(pgn, all_users=False)
+
+    pl = sub.add_parser("list", help="Names-only listing")
+    pl.add_argument("--json", action="store_true")
+    _add_admin_flags(pl)
+
+    pd = sub.add_parser("delete", help="Remove a secret")
+    pd.add_argument("name")
+    pd.add_argument("--json", action="store_true")
+    _add_admin_flags(pd, all_users=False)
+
+    return p
+
+
+def _add_admin_flags(p: argparse.ArgumentParser, *, all_users: bool = True) -> None:
+    grp = p.add_mutually_exclusive_group()
+    grp.add_argument("--user", metavar="NAME", help="(sudo) operate on another user's store")
+    if all_users:
+        grp.add_argument(
+            "--all-users",
+            action="store_true",
+            help="(sudo, read-only) operate across all users",
+        )
+
+
+def _dispatch(args: argparse.Namespace) -> int:
+    handler = _HANDLERS.get(args.cmd)
+    if handler is None:
+        _build_parser().print_help()
+        return EXIT_SUCCESS
+    return handler(args)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
-    parser.parse_args(argv)
-    # Scaffold behaviour: no args → print version and exit 0.
-    print(f"{PROG} {__version__}")
-    return 0
+    args = parser.parse_args(argv)
+    json_mode = getattr(args, "json", False)
+    if args.cmd is None:
+        print(f"{PROG} {__version__}")
+        return EXIT_SUCCESS
+    try:
+        return _dispatch(args)
+    except ShushuError as exc:
+        _output.emit_error(exc, json_mode=json_mode)
+        return exc.code
+    except store.ValidationError as exc:
+        _output.emit_error(
+            ShushuError(EXIT_USER_ERROR, str(exc), "see: shushu explain set"),
+            json_mode=json_mode,
+        )
+        return EXIT_USER_ERROR
+    except store.NotFoundError as exc:
+        _output.emit_error(
+            ShushuError(EXIT_USER_ERROR, str(exc), "see: shushu list"),
+            json_mode=json_mode,
+        )
+        return EXIT_USER_ERROR
+    except store.HiddenError as exc:
+        _output.emit_error(
+            ShushuError(EXIT_USER_ERROR, str(exc), "see: shushu run --inject"),
+            json_mode=json_mode,
+        )
+        return EXIT_USER_ERROR
+    except store.StateError as exc:
+        _output.emit_error(
+            ShushuError(
+                EXIT_STATE,
+                str(exc),
+                "check your ~/.local/share/shushu/ for corruption",
+            ),
+            json_mode=json_mode,
+        )
+        return EXIT_STATE
+    except privilege.PrivilegeError as exc:
+        _output.emit_error(
+            ShushuError(EXIT_PRIVILEGE, exc.message, exc.remediation),
+            json_mode=json_mode,
+        )
+        return EXIT_PRIVILEGE
+    except NotImplementedError as exc:
+        _output.emit_error(
+            ShushuError(
+                EXIT_USER_ERROR,
+                f"not implemented: {exc}",
+                "coming in a later task",
+            ),
+            json_mode=json_mode,
+        )
+        return EXIT_USER_ERROR
+    except Exception as exc:  # pragma: no cover
+        tb = traceback.format_exc()
+        _output.emit_error(
+            ShushuError(
+                EXIT_INTERNAL,
+                f"unexpected error: {exc!r}",
+                "please file an issue at github.com/agentculture/shushu/issues with the above",
+            ),
+            json_mode=json_mode,
+        )
+        sys.stderr.write(tb)
+        return EXIT_INTERNAL
 
 
 __all__ = ["main"]

--- a/src/shushu/cli/__init__.py
+++ b/src/shushu/cli/__init__.py
@@ -22,7 +22,9 @@ from shushu.cli._commands import (
     run,
 )
 from shushu.cli._commands import set as set_cmd
-from shushu.cli._commands import show
+from shushu.cli._commands import (
+    show,
+)
 from shushu.cli._errors import (
     EXIT_INTERNAL,
     EXIT_PRIVILEGE,

--- a/src/shushu/cli/_commands/delete.py
+++ b/src/shushu/cli/_commands/delete.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def handle(args) -> int:
+    raise NotImplementedError("delete: implemented in Task 25")

--- a/src/shushu/cli/_commands/doctor.py
+++ b/src/shushu/cli/_commands/doctor.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def handle(args) -> int:
+    raise NotImplementedError("doctor: implemented in Task 16")

--- a/src/shushu/cli/_commands/env.py
+++ b/src/shushu/cli/_commands/env.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def handle(args) -> int:
+    raise NotImplementedError("env: implemented in Task 22")

--- a/src/shushu/cli/_commands/explain.py
+++ b/src/shushu/cli/_commands/explain.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def handle(args) -> int:
+    raise NotImplementedError("explain: implemented in Task 15")

--- a/src/shushu/cli/_commands/generate.py
+++ b/src/shushu/cli/_commands/generate.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def handle(args) -> int:
+    raise NotImplementedError("generate: implemented in Task 19")

--- a/src/shushu/cli/_commands/get.py
+++ b/src/shushu/cli/_commands/get.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def handle(args) -> int:
+    raise NotImplementedError("get: implemented in Task 21")

--- a/src/shushu/cli/_commands/learn.py
+++ b/src/shushu/cli/_commands/learn.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def handle(args) -> int:
+    raise NotImplementedError("learn: implemented in Task 15")

--- a/src/shushu/cli/_commands/list_.py
+++ b/src/shushu/cli/_commands/list_.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def handle(args) -> int:
+    raise NotImplementedError("list: implemented in Task 24")

--- a/src/shushu/cli/_commands/overview.py
+++ b/src/shushu/cli/_commands/overview.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def handle(args) -> int:
+    raise NotImplementedError("overview: implemented in Task 17")

--- a/src/shushu/cli/_commands/run.py
+++ b/src/shushu/cli/_commands/run.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def handle(args) -> int:
+    raise NotImplementedError("run: implemented in Task 23")

--- a/src/shushu/cli/_commands/set.py
+++ b/src/shushu/cli/_commands/set.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def handle(args) -> int:
+    raise NotImplementedError("set: implemented in Task 18")

--- a/src/shushu/cli/_commands/show.py
+++ b/src/shushu/cli/_commands/show.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def handle(args) -> int:
+    raise NotImplementedError("show: implemented in Task 20")

--- a/src/shushu/cli/_errors.py
+++ b/src/shushu/cli/_errors.py
@@ -1,0 +1,44 @@
+"""Error discipline: ShushuError + EXIT_* constants.
+
+Every handler raises ShushuError. The dispatcher catches and routes
+through _output.emit_error. Unknown exceptions wrap to EXIT_INTERNAL.
+"""
+
+from __future__ import annotations
+
+EXIT_SUCCESS = 0
+EXIT_USER_ERROR = 64
+EXIT_STATE = 65
+EXIT_PRIVILEGE = 66
+EXIT_BACKEND = 67
+EXIT_CONFLICT = 68
+EXIT_INTERNAL = 70
+
+_EXIT_NAMES = {
+    EXIT_SUCCESS: "EXIT_SUCCESS",
+    EXIT_USER_ERROR: "EXIT_USER_ERROR",
+    EXIT_STATE: "EXIT_STATE",
+    EXIT_PRIVILEGE: "EXIT_PRIVILEGE",
+    EXIT_BACKEND: "EXIT_BACKEND",
+    EXIT_CONFLICT: "EXIT_CONFLICT",
+    EXIT_INTERNAL: "EXIT_INTERNAL",
+}
+
+
+class ShushuError(Exception):
+    """Structured error: exit code + human message + remediation."""
+
+    def __init__(self, code: int, message: str, remediation: str) -> None:  # noqa: B042
+        # B042 would prefer super().__init__(code, message, remediation) for
+        # pickle round-trips, but that makes str(exc) a tuple repr. We
+        # pass only message so str(exc) stays readable; code and
+        # remediation live as attributes. Same pattern as PrivilegeError
+        # in shushu.privilege.
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.remediation = remediation
+
+    @property
+    def name(self) -> str:
+        return _EXIT_NAMES.get(self.code, f"EXIT_{self.code}")

--- a/src/shushu/cli/_output.py
+++ b/src/shushu/cli/_output.py
@@ -1,0 +1,62 @@
+"""Output helpers: text vs. JSON modes.
+
+Rules:
+- `--json` → ONE JSON object on stdout, nothing else.
+- Text mode → concise human output on stdout; warnings go to stderr.
+- Errors share the same shape (text vs. JSON) and always include a
+  remediation field.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import IO, Any
+
+from shushu.cli._errors import ShushuError
+
+
+def emit_result(payload: Any, *, json_mode: bool, stream: IO[str] | None = None) -> None:
+    stream = stream or sys.stdout
+    if json_mode:
+        wrapped: dict[str, Any] = {"ok": True}
+        if isinstance(payload, dict):
+            wrapped.update(payload)
+        elif payload is not None:
+            wrapped["result"] = payload
+        stream.write(json.dumps(wrapped) + "\n")
+    elif payload is None:
+        return
+    else:
+        if isinstance(payload, str):
+            stream.write(payload)
+            if not payload.endswith("\n"):
+                stream.write("\n")
+        else:
+            stream.write(str(payload) + "\n")
+
+
+def emit_error(err: ShushuError, *, json_mode: bool, stream: IO[str] | None = None) -> None:
+    stream = stream or sys.stderr
+    if json_mode:
+        payload = {
+            "ok": False,
+            "error": {
+                "code": err.code,
+                "name": err.name,
+                "message": err.message,
+                "remediation": err.remediation,
+            },
+        }
+        stream.write(json.dumps(payload) + "\n")
+    else:
+        stream.write(f"shushu: error: {err.message}; {err.remediation}\n")
+
+
+def emit_warning(message: str, *, json_mode: bool) -> None:
+    """Warnings always go to stderr, regardless of json_mode, so agent
+    stdout parsing stays clean."""
+    if not json_mode:
+        sys.stderr.write(f"shushu: warning: {message}\n")
+    # In json_mode we suppress warnings entirely (payloads carry their own
+    # structured alert info when relevant).

--- a/src/shushu/cli/_output.py
+++ b/src/shushu/cli/_output.py
@@ -37,7 +37,11 @@ def emit_result(payload: Any, *, json_mode: bool, stream: IO[str] | None = None)
 
 
 def emit_error(err: ShushuError, *, json_mode: bool, stream: IO[str] | None = None) -> None:
-    stream = stream or sys.stderr
+    if stream is None:
+        # --json contract: one JSON object on stdout (success OR error), so
+        # callers can `payload = json.loads(proc.stdout)` regardless of exit
+        # code. Text mode keeps errors on stderr so stdout stays clean.
+        stream = sys.stdout if json_mode else sys.stderr
     if json_mode:
         payload = {
             "ok": False,

--- a/src/shushu/fs.py
+++ b/src/shushu/fs.py
@@ -1,0 +1,96 @@
+"""Filesystem primitives for shushu stores.
+
+Responsibilities:
+- Path construction (respects SHUSHU_HOME for tests only).
+- Directory creation with explicit modes (umask ignored).
+- Atomic write: write-to-temp-in-same-dir → fsync → os.replace.
+- fcntl advisory locking for concurrent safety.
+
+Does NOT know about JSON, schema, or shushu-specific semantics.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class StorePaths:
+    dir: Path
+    file: Path
+    lock: Path
+
+
+def user_store_paths(home: Path | None = None) -> StorePaths:
+    """Paths for the store owned by the current process's euid.
+
+    Honors SHUSHU_HOME for tests (placed in a temp dir). In production
+    this resolves to ~/.local/share/shushu/.
+    """
+    override = os.environ.get("SHUSHU_HOME")
+    if override:
+        base = Path(override)
+    else:
+        base = (home or Path.home()) / ".local/share/shushu"
+    return StorePaths(dir=base, file=base / "secrets.json", lock=base / ".lock")
+
+
+def ensure_store_dir(paths: StorePaths | None = None) -> StorePaths:
+    paths = paths or user_store_paths()
+    paths.dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    # Defensive: mkdir with exist_ok=True does NOT chmod an existing dir.
+    # Fix up if the dir pre-existed with a wrong mode.
+    os.chmod(paths.dir, 0o700)
+    # Pre-create an empty lockfile so fcntl has something to hold.
+    if not paths.lock.exists():
+        fd = os.open(paths.lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        os.close(fd)
+    os.chmod(paths.lock, 0o600)
+    return paths
+
+
+def atomic_write_text(target: Path, text: str, mode: int = 0o600) -> None:
+    """Atomically replace `target` with `text`. Never leaves a partial file."""
+    tmp = target.with_name(f"{target.name}.{os.getpid()}.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp, mode)
+        os.replace(tmp, target)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+@contextlib.contextmanager
+def locked_write(paths: StorePaths | None = None):
+    """Exclusive advisory lock for the duration of a write."""
+    paths = paths or user_store_paths()
+    ensure_store_dir(paths)
+    fd = os.open(paths.lock, os.O_RDWR)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield fd
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+@contextlib.contextmanager
+def locked_read(paths: StorePaths | None = None):
+    paths = paths or user_store_paths()
+    ensure_store_dir(paths)
+    fd = os.open(paths.lock, os.O_RDONLY)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_SH)
+        yield fd
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)

--- a/src/shushu/fs.py
+++ b/src/shushu/fs.py
@@ -46,9 +46,11 @@ def ensure_store_dir(paths: StorePaths | None = None) -> StorePaths:
     # Fix up if the dir pre-existed with a wrong mode.
     os.chmod(paths.dir, 0o700)
     # Pre-create an empty lockfile so fcntl has something to hold.
-    if not paths.lock.exists():
-        fd = os.open(paths.lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        os.close(fd)
+    # O_CREAT (without O_EXCL) is race-safe for concurrent first-run callers:
+    # both will open the file; the non-creating caller just gets an fd to
+    # the existing lockfile. The chmod below asserts mode 0600 regardless.
+    fd = os.open(paths.lock, os.O_CREAT | os.O_WRONLY, 0o600)
+    os.close(fd)
     os.chmod(paths.lock, 0o600)
     return paths
 

--- a/src/shushu/generate.py
+++ b/src/shushu/generate.py
@@ -1,0 +1,26 @@
+"""Random secret generation.
+
+Wraps `secrets.token_bytes` with hex/base64 encoding. No crypto policy
+decisions beyond picking a sensible default size (32 bytes — 256 bits).
+"""
+
+from __future__ import annotations
+
+import base64
+import secrets as _secrets
+from typing import Literal
+
+Encoding = Literal["hex", "base64"]
+DEFAULT_BYTES = 32
+DEFAULT_ENCODING: Encoding = "hex"
+
+
+def random_secret(nbytes: int = DEFAULT_BYTES, encoding: Encoding = DEFAULT_ENCODING) -> str:
+    if nbytes <= 0:
+        raise ValueError(f"nbytes must be positive, got {nbytes}")
+    raw = _secrets.token_bytes(nbytes)
+    if encoding == "hex":
+        return raw.hex()
+    if encoding == "base64":
+        return base64.b64encode(raw).decode("ascii")
+    raise ValueError(f"unknown encoding: {encoding!r} (expected 'hex' or 'base64')")

--- a/src/shushu/privilege.py
+++ b/src/shushu/privilege.py
@@ -18,8 +18,13 @@ from shushu.users import UserInfo
 class PrivilegeError(Exception):
     """Raised when an operation requires root and the process is not root."""
 
-    def __init__(self, message: str, remediation: str) -> None:
-        super().__init__(message, remediation)
+    def __init__(self, message: str, remediation: str) -> None:  # noqa: B042
+        # B042 would prefer `super().__init__(message, remediation)` for
+        # pickle round-trips, but that makes `str(exc)` a tuple repr and
+        # breaks readable error output. PrivilegeError is not pickled
+        # anywhere in shushu; we keep str(exc) clean and expose
+        # remediation via the attribute.
+        super().__init__(message)
         self.message = message
         self.remediation = remediation
 

--- a/src/shushu/privilege.py
+++ b/src/shushu/privilege.py
@@ -1,0 +1,95 @@
+"""Privilege handling: euid checks, sudo advice, setuid-fork for handoff.
+
+The setuid-fork helper is the ONLY place in shushu that changes uid/gid.
+Every admin-write verb routes through `run_as_user` before touching disk.
+"""
+
+from __future__ import annotations
+
+import os
+import pwd
+import shutil
+import sys
+from collections.abc import Callable
+
+from shushu.users import UserInfo
+
+
+class PrivilegeError(Exception):
+    """Raised when an operation requires root and the process is not root."""
+
+    def __init__(self, message: str, remediation: str) -> None:
+        super().__init__(message, remediation)
+        self.message = message
+        self.remediation = remediation
+
+
+def resolve_shushu_path() -> str:
+    """Absolute path to the currently-installed shushu executable.
+
+    `uv tool install` places the binary under ~/.local/bin, which is
+    typically absent from root's secure_path — so advising `sudo shushu`
+    without the resolved path is a common foot-gun. Fall back to `shushu`
+    if which() finds nothing (first-install quirk).
+    """
+    return shutil.which("shushu") or "shushu"
+
+
+def require_root(command_tail: str) -> None:
+    if os.geteuid() == 0:
+        return
+    path = resolve_shushu_path()
+    raise PrivilegeError(
+        message="this operation requires root",
+        remediation=f"re-run with: sudo {path} {command_tail}",
+    )
+
+
+def sudo_invoker() -> str:
+    """Best-guess name of the human who invoked sudo.
+
+    Prefers $SUDO_USER (set by sudo itself). Falls back to the process's
+    real uid (which under sudo is the original caller). Guaranteed non-empty.
+    """
+    name = os.environ.get("SUDO_USER")
+    if name:
+        return name
+    return pwd.getpwuid(os.getuid()).pw_name
+
+
+def run_as_user(user: UserInfo, fn: Callable[[], int]) -> int:
+    """Fork a child, drop to (user.uid, user.gid), call fn(), exit with its return code.
+
+    Must be invoked with geteuid() == 0 in the parent. Returns the child's
+    exit status to the parent.
+    """
+    if os.geteuid() != 0:
+        raise PrivilegeError(
+            message="run_as_user requires euid=0 in the parent",
+            remediation="this is a programming error; admin handlers must call require_root first",
+        )
+    pid = os.fork()
+    if pid == 0:  # child
+        _become(user)
+        try:
+            rc = fn()
+        except PrivilegeError as exc:
+            sys.stderr.write(f"shushu: error: {exc.message}\n  → {exc.remediation}\n")
+            os._exit(66)
+        except Exception as exc:  # pragma: no cover
+            sys.stderr.write(f"shushu: internal error in admin handoff: {exc!r}\n")
+            os._exit(70)
+        os._exit(rc)
+    _, status = os.waitpid(pid, 0)
+    if os.WIFEXITED(status):
+        return os.WEXITSTATUS(status)
+    return 67  # EXIT_BACKEND — child died abnormally
+
+
+def _become(user: UserInfo) -> None:
+    """Switch identity. Order matters: setgroups → setgid → setuid."""
+    os.setgroups([])
+    os.setgid(user.gid)
+    os.setegid(user.gid)
+    os.setuid(user.uid)
+    os.seteuid(user.uid)

--- a/src/shushu/store.py
+++ b/src/shushu/store.py
@@ -107,7 +107,18 @@ def _dt_to_str(dt: datetime) -> str:
 
 
 def _str_to_dt(s: str) -> datetime:
-    return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    # Literal 'Z' in the format string matches the letter, not a tz
+    # designator — we attach UTC via replace(). Leaving strict format
+    # (no microseconds) per the design spec's seconds-precision wire
+    # format; improve the error message so hand-edits don't produce a
+    # cryptic strptime traceback.
+    try:
+        return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        raise ValueError(
+            f"non-canonical datetime {s!r}; expected seconds precision "
+            f"(`YYYY-MM-DDTHH:MM:SSZ`, e.g. '2026-04-24T12:00:00Z')"
+        ) from exc
 
 
 def _now_utc() -> datetime:
@@ -121,18 +132,32 @@ def _paths() -> fs.StorePaths:
     return fs.user_store_paths()
 
 
-def load() -> StoreData:
+def _load_raw_unlocked() -> StoreData:
+    """Read + parse secrets.json without acquiring a lock.
+
+    Only safe to call from within a `locked_write()` context. The public
+    `load()` takes LOCK_SH; this helper assumes the caller already holds
+    LOCK_EX via locked_write and would deadlock if it tried LOCK_SH on
+    the same lockfile.
+    """
     paths = _paths()
     if not paths.file.exists():
         return StoreData(schema_version=SCHEMA_VERSION, secrets=[])
     try:
-        with fs.locked_read(paths):
-            raw = json.loads(paths.file.read_text(encoding="utf-8"))
+        raw = json.loads(paths.file.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise StateError(f"secrets.json is not valid JSON: {exc}")
     sv = raw.get("schema_version")
+    if not isinstance(sv, int):
+        raise StateError(
+            f"secrets.json is missing or has non-integer schema_version "
+            f"(got {sv!r}); file may be corrupt or hand-edited"
+        )
     if sv != SCHEMA_VERSION:
-        raise StateError(f"store schema_version={sv} but this binary supports {SCHEMA_VERSION}")
+        raise StateError(
+            f"store schema_version={sv} but this binary supports {SCHEMA_VERSION}; "
+            "upgrade shushu or file a migration issue"
+        )
     try:
         secrets = [_json_to_record(d) for d in raw.get("secrets", [])]
     except (KeyError, ValueError) as exc:
@@ -140,14 +165,33 @@ def load() -> StoreData:
     return StoreData(schema_version=SCHEMA_VERSION, secrets=secrets)
 
 
+def _save_unlocked(data: StoreData) -> None:
+    """Write secrets.json atomically without acquiring a lock. Only safe
+    to call from within a `locked_write()` context."""
+    paths = _paths()
+    payload = {
+        "schema_version": data.schema_version,
+        "secrets": [_record_to_json(r) for r in data.secrets],
+    }
+    fs.atomic_write_text(paths.file, json.dumps(payload, indent=2) + "\n")
+
+
+def load() -> StoreData:
+    """Public read path. Acquires shared lock; safe for concurrent readers."""
+    paths = _paths()
+    if not paths.file.exists():
+        return StoreData(schema_version=SCHEMA_VERSION, secrets=[])
+    with fs.locked_read(paths):
+        return _load_raw_unlocked()
+
+
 def _save(data: StoreData) -> None:
+    """Public write path (currently unused — mutations use locked_write
+    blocks directly so they can load + mutate + save under a single
+    LOCK_EX). Kept for any future single-shot-write use case."""
     paths = _paths()
     with fs.locked_write(paths):
-        payload = {
-            "schema_version": data.schema_version,
-            "secrets": [_record_to_json(r) for r in data.secrets],
-        }
-        fs.atomic_write_text(paths.file, json.dumps(payload, indent=2) + "\n")
+        _save_unlocked(data)
 
 
 # --- validation ----------------------------------------------------------
@@ -165,6 +209,10 @@ def _validate_name(name: str) -> None:
 
 IMMUTABLE_FIELDS = ("source", "hidden", "created_at", "handed_over_by", "name")
 MUTABLE_META_FIELDS = ("purpose", "rotation_howto", "alert_at")
+# These tuples are exported for CLI-layer consumers (Task 13+) to list
+# mutable fields in `shushu explain` / `shushu doctor` output and enforce
+# flag-level immutability checks before calling into the store. Not
+# consumed inside this module.
 
 
 def set_secret(
@@ -178,51 +226,60 @@ def set_secret(
     alert_at: date | None = None,
     handed_over_by: str | None = None,
 ) -> SecretRecord:
-    """Create or overwrite the named secret. Overwrite preserves
-    created_at, source, hidden, handed_over_by (all immutable)."""
+    """Create or overwrite the named secret.
+
+    Overwrite preserves immutables (`created_at`, `source`, `hidden`,
+    `handed_over_by`). For mutable metadata (`purpose`, `rotation_howto`,
+    `alert_at`), overwrite falls through falsy/None args to the existing
+    record — passing `purpose=""` will NOT clear a prior non-empty
+    purpose via this method. Use `update_metadata(purpose="")` when you
+    need to explicitly clear a mutable field (None means "leave alone",
+    "" means "set to empty").
+    """
     _validate_name(name)
-    data = load()
-    existing = _find(data, name)
-    now = _now_utc()
-    if existing is None:
-        rec = SecretRecord(
-            name=name,
-            value=value,
-            hidden=hidden,
-            source=source,
-            purpose=purpose,
-            rotation_howto=rotation_howto,
-            alert_at=alert_at,
-            handed_over_by=handed_over_by,
-            created_at=now,
-            updated_at=now,
-        )
-        new_secrets = [*data.secrets, rec]
-    else:
-        # Overwrite: value changes; immutables stay; mutables may change
-        # if the caller passed new ones. For v1, set_secret-with-value
-        # preserves all metadata unless new flags were explicitly given.
-        # The CLI layer is responsible for not passing new source/hidden
-        # on overwrite; store enforces the invariant via update_metadata.
-        if existing.source != source:
-            raise ValidationError("source is immutable post-create; delete and re-create to change")
-        if existing.hidden != hidden:
-            raise ValidationError("hidden is immutable post-create; delete and re-create to change")
-        rec = SecretRecord(
-            name=existing.name,
-            value=value,
-            hidden=existing.hidden,
-            source=existing.source,
-            purpose=purpose or existing.purpose,
-            rotation_howto=rotation_howto or existing.rotation_howto,
-            alert_at=alert_at if alert_at is not None else existing.alert_at,
-            handed_over_by=existing.handed_over_by,
-            created_at=existing.created_at,
-            updated_at=now,
-        )
-        new_secrets = [r if r.name != name else rec for r in data.secrets]
-    _save(StoreData(schema_version=SCHEMA_VERSION, secrets=new_secrets))
-    return rec
+    paths = _paths()
+    with fs.locked_write(paths):
+        data = _load_raw_unlocked()
+        existing = _find(data, name)
+        now = _now_utc()
+        if existing is None:
+            rec = SecretRecord(
+                name=name,
+                value=value,
+                hidden=hidden,
+                source=source,
+                purpose=purpose,
+                rotation_howto=rotation_howto,
+                alert_at=alert_at,
+                handed_over_by=handed_over_by,
+                created_at=now,
+                updated_at=now,
+            )
+            new_secrets = [*data.secrets, rec]
+        else:
+            if existing.source != source:
+                raise ValidationError(
+                    "source is immutable post-create; delete and re-create to change"
+                )
+            if existing.hidden != hidden:
+                raise ValidationError(
+                    "hidden is immutable post-create; delete and re-create to change"
+                )
+            rec = SecretRecord(
+                name=existing.name,
+                value=value,
+                hidden=existing.hidden,
+                source=existing.source,
+                purpose=purpose or existing.purpose,
+                rotation_howto=rotation_howto or existing.rotation_howto,
+                alert_at=alert_at if alert_at is not None else existing.alert_at,
+                handed_over_by=existing.handed_over_by,
+                created_at=existing.created_at,
+                updated_at=now,
+            )
+            new_secrets = [r if r.name != name else rec for r in data.secrets]
+        _save_unlocked(StoreData(schema_version=SCHEMA_VERSION, secrets=new_secrets))
+        return rec
 
 
 def update_metadata(
@@ -233,31 +290,40 @@ def update_metadata(
     alert_at: date | None = None,
     **forbidden: Any,
 ) -> SecretRecord:
-    """Update only mutable metadata. Refuses attempts to touch immutables."""
+    """Update only mutable metadata. Refuses attempts to touch immutables.
+
+    Distinguishes `None` (leave field alone) from `""` (set to empty) for
+    string fields. For `alert_at`, `None` also means "leave alone" —
+    clearing once set is a v2 concern; use `delete` + re-create.
+    """
     if forbidden:
         bad = next(iter(forbidden))
         raise ValidationError(
             f"{bad!r} is immutable post-create; " "delete and re-create to change it"
         )
-    data = load()
-    existing = _find(data, name)
-    if existing is None:
-        raise NotFoundError(f"no secret named {name}")
-    rec = SecretRecord(
-        name=existing.name,
-        value=existing.value,
-        hidden=existing.hidden,
-        source=existing.source,
-        purpose=purpose if purpose is not None else existing.purpose,
-        rotation_howto=(rotation_howto if rotation_howto is not None else existing.rotation_howto),
-        alert_at=alert_at if alert_at is not None else existing.alert_at,
-        handed_over_by=existing.handed_over_by,
-        created_at=existing.created_at,
-        updated_at=_now_utc(),
-    )
-    new_secrets = [r if r.name != name else rec for r in data.secrets]
-    _save(StoreData(schema_version=SCHEMA_VERSION, secrets=new_secrets))
-    return rec
+    paths = _paths()
+    with fs.locked_write(paths):
+        data = _load_raw_unlocked()
+        existing = _find(data, name)
+        if existing is None:
+            raise NotFoundError(f"no secret named {name}")
+        rec = SecretRecord(
+            name=existing.name,
+            value=existing.value,
+            hidden=existing.hidden,
+            source=existing.source,
+            purpose=purpose if purpose is not None else existing.purpose,
+            rotation_howto=(
+                rotation_howto if rotation_howto is not None else existing.rotation_howto
+            ),
+            alert_at=alert_at if alert_at is not None else existing.alert_at,
+            handed_over_by=existing.handed_over_by,
+            created_at=existing.created_at,
+            updated_at=_now_utc(),
+        )
+        new_secrets = [r if r.name != name else rec for r in data.secrets]
+        _save_unlocked(StoreData(schema_version=SCHEMA_VERSION, secrets=new_secrets))
+        return rec
 
 
 def get_value(name: str) -> str:
@@ -281,12 +347,14 @@ def get_record(name: str) -> SecretRecord:
 
 
 def delete(name: str) -> None:
-    data = load()
-    rec = _find(data, name)
-    if rec is None:
-        raise NotFoundError(f"no secret named {name}")
-    new_secrets = [r for r in data.secrets if r.name != name]
-    _save(StoreData(schema_version=SCHEMA_VERSION, secrets=new_secrets))
+    paths = _paths()
+    with fs.locked_write(paths):
+        data = _load_raw_unlocked()
+        rec = _find(data, name)
+        if rec is None:
+            raise NotFoundError(f"no secret named {name}")
+        new_secrets = [r for r in data.secrets if r.name != name]
+        _save_unlocked(StoreData(schema_version=SCHEMA_VERSION, secrets=new_secrets))
 
 
 def list_names() -> list[str]:

--- a/src/shushu/store.py
+++ b/src/shushu/store.py
@@ -1,0 +1,300 @@
+"""Per-user secrets store on disk. Single source of truth for secrets.json.
+
+Responsibilities:
+- Load/save JSON under the per-user store dir.
+- Enforce schema_version and record-field validation.
+- Enforce immutability: source / hidden / created_at / handed_over_by / name.
+- Provide CRUD: set_secret, update_metadata, get_value, delete, list_names.
+- Expose typed errors for the CLI layer to turn into ShushuError exit codes.
+
+Does NOT know about sudo, argparse, or output formatting.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from typing import Any
+
+from shushu import fs
+
+SCHEMA_VERSION = 1
+NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]{0,63}$")
+
+# --- typed errors --------------------------------------------------------
+
+
+class StoreError(Exception):
+    """Base for store-level errors that the CLI translates to exit codes."""
+
+
+class ValidationError(StoreError):
+    """Input failed validation (bad name, bad date, immutable field)."""
+
+
+class NotFoundError(StoreError):
+    """Secret name not present in the store."""
+
+
+class HiddenError(StoreError):
+    """Attempt to read value of a hidden secret."""
+
+
+class StateError(StoreError):
+    """Store file corrupt / schema_version mismatch / unreadable."""
+
+
+# --- dataclasses ---------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SecretRecord:
+    name: str
+    value: str
+    hidden: bool
+    source: str
+    purpose: str
+    rotation_howto: str
+    alert_at: date | None
+    handed_over_by: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class StoreData:
+    schema_version: int
+    secrets: list[SecretRecord] = field(default_factory=list)
+
+
+# --- serialization -------------------------------------------------------
+
+
+def _record_to_json(r: SecretRecord) -> dict[str, Any]:
+    return {
+        "name": r.name,
+        "value": r.value,
+        "hidden": r.hidden,
+        "source": r.source,
+        "purpose": r.purpose,
+        "rotation_howto": r.rotation_howto,
+        "alert_at": r.alert_at.isoformat() if r.alert_at else None,
+        "handed_over_by": r.handed_over_by,
+        "created_at": _dt_to_str(r.created_at),
+        "updated_at": _dt_to_str(r.updated_at),
+    }
+
+
+def _json_to_record(d: dict[str, Any]) -> SecretRecord:
+    return SecretRecord(
+        name=d["name"],
+        value=d["value"],
+        hidden=bool(d["hidden"]),
+        source=d["source"],
+        purpose=d.get("purpose", ""),
+        rotation_howto=d.get("rotation_howto", ""),
+        alert_at=date.fromisoformat(d["alert_at"]) if d.get("alert_at") else None,
+        handed_over_by=d.get("handed_over_by"),
+        created_at=_str_to_dt(d["created_at"]),
+        updated_at=_str_to_dt(d["updated_at"]),
+    )
+
+
+def _dt_to_str(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _str_to_dt(s: str) -> datetime:
+    return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+# --- load / save ---------------------------------------------------------
+
+
+def _paths() -> fs.StorePaths:
+    return fs.user_store_paths()
+
+
+def load() -> StoreData:
+    paths = _paths()
+    if not paths.file.exists():
+        return StoreData(schema_version=SCHEMA_VERSION, secrets=[])
+    try:
+        with fs.locked_read(paths):
+            raw = json.loads(paths.file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise StateError(f"secrets.json is not valid JSON: {exc}")
+    sv = raw.get("schema_version")
+    if sv != SCHEMA_VERSION:
+        raise StateError(f"store schema_version={sv} but this binary supports {SCHEMA_VERSION}")
+    try:
+        secrets = [_json_to_record(d) for d in raw.get("secrets", [])]
+    except (KeyError, ValueError) as exc:
+        raise StateError(f"secrets.json contains malformed record: {exc}")
+    return StoreData(schema_version=SCHEMA_VERSION, secrets=secrets)
+
+
+def _save(data: StoreData) -> None:
+    paths = _paths()
+    with fs.locked_write(paths):
+        payload = {
+            "schema_version": data.schema_version,
+            "secrets": [_record_to_json(r) for r in data.secrets],
+        }
+        fs.atomic_write_text(paths.file, json.dumps(payload, indent=2) + "\n")
+
+
+# --- validation ----------------------------------------------------------
+
+
+def _validate_name(name: str) -> None:
+    if not NAME_RE.match(name):
+        raise ValidationError(
+            f"invalid name {name!r}; must match {NAME_RE.pattern} "
+            "(uppercase + underscore + digits, starts with letter/_, ≤64 chars)"
+        )
+
+
+# --- mutations -----------------------------------------------------------
+
+IMMUTABLE_FIELDS = ("source", "hidden", "created_at", "handed_over_by", "name")
+MUTABLE_META_FIELDS = ("purpose", "rotation_howto", "alert_at")
+
+
+def set_secret(
+    *,
+    name: str,
+    value: str,
+    hidden: bool,
+    source: str,
+    purpose: str,
+    rotation_howto: str = "",
+    alert_at: date | None = None,
+    handed_over_by: str | None = None,
+) -> SecretRecord:
+    """Create or overwrite the named secret. Overwrite preserves
+    created_at, source, hidden, handed_over_by (all immutable)."""
+    _validate_name(name)
+    data = load()
+    existing = _find(data, name)
+    now = _now_utc()
+    if existing is None:
+        rec = SecretRecord(
+            name=name,
+            value=value,
+            hidden=hidden,
+            source=source,
+            purpose=purpose,
+            rotation_howto=rotation_howto,
+            alert_at=alert_at,
+            handed_over_by=handed_over_by,
+            created_at=now,
+            updated_at=now,
+        )
+        new_secrets = [*data.secrets, rec]
+    else:
+        # Overwrite: value changes; immutables stay; mutables may change
+        # if the caller passed new ones. For v1, set_secret-with-value
+        # preserves all metadata unless new flags were explicitly given.
+        # The CLI layer is responsible for not passing new source/hidden
+        # on overwrite; store enforces the invariant via update_metadata.
+        if existing.source != source:
+            raise ValidationError("source is immutable post-create; delete and re-create to change")
+        if existing.hidden != hidden:
+            raise ValidationError("hidden is immutable post-create; delete and re-create to change")
+        rec = SecretRecord(
+            name=existing.name,
+            value=value,
+            hidden=existing.hidden,
+            source=existing.source,
+            purpose=purpose or existing.purpose,
+            rotation_howto=rotation_howto or existing.rotation_howto,
+            alert_at=alert_at if alert_at is not None else existing.alert_at,
+            handed_over_by=existing.handed_over_by,
+            created_at=existing.created_at,
+            updated_at=now,
+        )
+        new_secrets = [r if r.name != name else rec for r in data.secrets]
+    _save(StoreData(schema_version=SCHEMA_VERSION, secrets=new_secrets))
+    return rec
+
+
+def update_metadata(
+    *,
+    name: str,
+    purpose: str | None = None,
+    rotation_howto: str | None = None,
+    alert_at: date | None = None,
+    **forbidden: Any,
+) -> SecretRecord:
+    """Update only mutable metadata. Refuses attempts to touch immutables."""
+    if forbidden:
+        bad = next(iter(forbidden))
+        raise ValidationError(
+            f"{bad!r} is immutable post-create; " "delete and re-create to change it"
+        )
+    data = load()
+    existing = _find(data, name)
+    if existing is None:
+        raise NotFoundError(f"no secret named {name}")
+    rec = SecretRecord(
+        name=existing.name,
+        value=existing.value,
+        hidden=existing.hidden,
+        source=existing.source,
+        purpose=purpose if purpose is not None else existing.purpose,
+        rotation_howto=(rotation_howto if rotation_howto is not None else existing.rotation_howto),
+        alert_at=alert_at if alert_at is not None else existing.alert_at,
+        handed_over_by=existing.handed_over_by,
+        created_at=existing.created_at,
+        updated_at=_now_utc(),
+    )
+    new_secrets = [r if r.name != name else rec for r in data.secrets]
+    _save(StoreData(schema_version=SCHEMA_VERSION, secrets=new_secrets))
+    return rec
+
+
+def get_value(name: str) -> str:
+    data = load()
+    rec = _find(data, name)
+    if rec is None:
+        raise NotFoundError(f"no secret named {name}")
+    if rec.hidden:
+        raise HiddenError(
+            f"{name} is a hidden secret; use `shushu run --inject VAR={name} -- <cmd>`"
+        )
+    return rec.value
+
+
+def get_record(name: str) -> SecretRecord:
+    data = load()
+    rec = _find(data, name)
+    if rec is None:
+        raise NotFoundError(f"no secret named {name}")
+    return rec
+
+
+def delete(name: str) -> None:
+    data = load()
+    rec = _find(data, name)
+    if rec is None:
+        raise NotFoundError(f"no secret named {name}")
+    new_secrets = [r for r in data.secrets if r.name != name]
+    _save(StoreData(schema_version=SCHEMA_VERSION, secrets=new_secrets))
+
+
+def list_names() -> list[str]:
+    return sorted(r.name for r in load().secrets)
+
+
+def _find(data: StoreData, name: str) -> SecretRecord | None:
+    for r in data.secrets:
+        if r.name == name:
+            return r
+    return None

--- a/src/shushu/store.py
+++ b/src/shushu/store.py
@@ -88,10 +88,19 @@ def _record_to_json(r: SecretRecord) -> dict[str, Any]:
 
 
 def _json_to_record(d: dict[str, Any]) -> SecretRecord:
+    hidden_raw = d["hidden"]
+    if not isinstance(hidden_raw, bool):
+        # Strict check: bool(non-bool) silently coerces (e.g. bool("false") is
+        # True), which would defeat the schema-enforced contract for hand-edited
+        # or corrupt stores. Reject anything that isn't an actual JSON bool.
+        raise StateError(
+            f"secret {d.get('name', '?')!r} has non-boolean hidden "
+            f"(got {type(hidden_raw).__name__})"
+        )
     return SecretRecord(
         name=d["name"],
         value=d["value"],
-        hidden=bool(d["hidden"]),
+        hidden=hidden_raw,
         source=d["source"],
         purpose=d.get("purpose", ""),
         rotation_howto=d.get("rotation_howto", ""),
@@ -135,10 +144,11 @@ def _paths() -> fs.StorePaths:
 def _load_raw_unlocked() -> StoreData:
     """Read + parse secrets.json without acquiring a lock.
 
-    Only safe to call from within a `locked_write()` context. The public
-    `load()` takes LOCK_SH; this helper assumes the caller already holds
-    LOCK_EX via locked_write and would deadlock if it tried LOCK_SH on
-    the same lockfile.
+    Caller must already hold either LOCK_SH (for read-only paths like
+    public `load()`) or LOCK_EX (for read-mutate-write cycles inside the
+    `set_secret` / `update_metadata` / `delete` functions). The
+    `_unlocked` suffix means "this function does not acquire a lock
+    itself", not "the file is unlocked when this runs".
     """
     paths = _paths()
     if not paths.file.exists():
@@ -158,9 +168,14 @@ def _load_raw_unlocked() -> StoreData:
             f"store schema_version={sv} but this binary supports {SCHEMA_VERSION}; "
             "upgrade shushu or file a migration issue"
         )
+    secrets_raw = raw.get("secrets", [])
+    if not isinstance(secrets_raw, list):
+        raise StateError(
+            f"secrets.json 'secrets' field must be a list " f"(got {type(secrets_raw).__name__})"
+        )
     try:
-        secrets = [_json_to_record(d) for d in raw.get("secrets", [])]
-    except (KeyError, ValueError) as exc:
+        secrets = [_json_to_record(d) for d in secrets_raw]
+    except (KeyError, ValueError, TypeError) as exc:
         raise StateError(f"secrets.json contains malformed record: {exc}")
     return StoreData(schema_version=SCHEMA_VERSION, secrets=secrets)
 
@@ -177,10 +192,13 @@ def _save_unlocked(data: StoreData) -> None:
 
 
 def load() -> StoreData:
-    """Public read path. Acquires shared lock; safe for concurrent readers."""
+    """Public read path. Acquires shared lock; safe for concurrent readers.
+
+    The existence check happens inside `_load_raw_unlocked()`, under the
+    lock, to avoid a TOCTOU where a concurrent writer creates the file
+    after we check `exists()` but before we read.
+    """
     paths = _paths()
-    if not paths.file.exists():
-        return StoreData(schema_version=SCHEMA_VERSION, secrets=[])
     with fs.locked_read(paths):
         return _load_raw_unlocked()
 

--- a/src/shushu/store.py
+++ b/src/shushu/store.py
@@ -171,7 +171,7 @@ def _load_raw_unlocked() -> StoreData:
     secrets_raw = raw.get("secrets", [])
     if not isinstance(secrets_raw, list):
         raise StateError(
-            f"secrets.json 'secrets' field must be a list " f"(got {type(secrets_raw).__name__})"
+            f"secrets.json 'secrets' field must be a list (got {type(secrets_raw).__name__})"
         )
     try:
         secrets = [_json_to_record(d) for d in secrets_raw]

--- a/src/shushu/users.py
+++ b/src/shushu/users.py
@@ -1,0 +1,41 @@
+"""OS user enumeration and resolution.
+
+Thin wrapper over `pwd` so the rest of shushu speaks one dataclass.
+Used by privilege handoff and admin --all-users enumeration.
+"""
+
+from __future__ import annotations
+
+import os
+import pwd
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class UserInfo:
+    name: str
+    uid: int
+    gid: int
+    home: Path
+
+
+def _from_pwnam(entry: pwd.struct_passwd) -> UserInfo:
+    return UserInfo(
+        name=entry.pw_name,
+        uid=entry.pw_uid,
+        gid=entry.pw_gid,
+        home=Path(entry.pw_dir),
+    )
+
+
+def current() -> UserInfo:
+    return _from_pwnam(pwd.getpwuid(os.geteuid()))
+
+
+def resolve(name: str) -> UserInfo:
+    return _from_pwnam(pwd.getpwnam(name))
+
+
+def all_users() -> list[UserInfo]:
+    return [_from_pwnam(e) for e in pwd.getpwall()]

--- a/tests/unit/test_alerts.py
+++ b/tests/unit/test_alerts.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from shushu import alerts
+
+
+def _today(y, m, d):
+    return date(y, m, d)
+
+
+def test_classify_none_returns_ok():
+    assert alerts.classify(None, today=_today(2026, 4, 24)) == "ok"
+
+
+def test_classify_far_future_returns_ok():
+    assert alerts.classify(date(2027, 1, 1), today=_today(2026, 4, 24)) == "ok"
+
+
+def test_classify_within_30_days_returns_alerting():
+    assert alerts.classify(date(2026, 5, 10), today=_today(2026, 4, 24)) == "alerting"
+
+
+def test_classify_today_returns_alerting():
+    assert alerts.classify(date(2026, 4, 24), today=_today(2026, 4, 24)) == "alerting"
+
+
+def test_classify_past_returns_expired():
+    assert alerts.classify(date(2026, 4, 23), today=_today(2026, 4, 24)) == "expired"
+
+
+@pytest.mark.parametrize("s", ["2026-04-24", "2099-12-31"])
+def test_parse_date_accepts_iso(s):
+    assert alerts.parse_date(s) is not None
+
+
+def test_parse_date_rejects_malformed():
+    with pytest.raises(ValueError):
+        alerts.parse_date("2026-13-40")
+
+
+def test_parse_date_accepts_none_and_empty():
+    assert alerts.parse_date(None) is None
+    assert alerts.parse_date("") is None

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import sys
 
 from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 from shushu.cli._output import emit_error, emit_result
@@ -50,3 +51,25 @@ def test_emit_result_json_wraps_payload_in_ok_true():
     emit_result({"name": "FOO"}, json_mode=True, stream=buf)
     payload = json.loads(buf.getvalue())
     assert payload == {"ok": True, "name": "FOO"}
+
+
+def test_emit_error_json_default_stream_is_stdout(monkeypatch):
+    """In --json mode, both success AND error responses go to stdout, so
+    callers can `payload = json.loads(proc.stdout)` regardless of exit code."""
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    emit_error(ShushuError(EXIT_USER_ERROR, "oops", "fix it"), json_mode=True)
+    assert buf.getvalue()  # non-empty
+    payload = json.loads(buf.getvalue())
+    assert payload["ok"] is False
+
+
+def test_emit_error_text_default_stream_is_stderr(monkeypatch):
+    """Text mode keeps errors on stderr so stdout stays clean for piping."""
+    out_buf = io.StringIO()
+    err_buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out_buf)
+    monkeypatch.setattr(sys, "stderr", err_buf)
+    emit_error(ShushuError(EXIT_USER_ERROR, "oops", "fix it"), json_mode=False)
+    assert out_buf.getvalue() == ""
+    assert "shushu: error: oops" in err_buf.getvalue()

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import io
+import json
+
+from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
+from shushu.cli._output import emit_error, emit_result
+
+
+def test_emit_error_text_single_line():
+    buf = io.StringIO()
+    emit_error(
+        ShushuError(EXIT_USER_ERROR, "FOO is hidden", "use `shushu run --inject`"),
+        json_mode=False,
+        stream=buf,
+    )
+    line = buf.getvalue()
+    assert line.count("\n") == 1
+    assert "shushu: error: FOO is hidden" in line
+    assert "use `shushu run --inject`" in line
+
+
+def test_emit_error_json_structured():
+    buf = io.StringIO()
+    emit_error(
+        ShushuError(EXIT_USER_ERROR, "FOO is hidden", "use inject"),
+        json_mode=True,
+        stream=buf,
+    )
+    payload = json.loads(buf.getvalue())
+    assert payload == {
+        "ok": False,
+        "error": {
+            "code": 64,
+            "name": "EXIT_USER_ERROR",
+            "message": "FOO is hidden",
+            "remediation": "use inject",
+        },
+    }
+
+
+def test_emit_result_text_noop_on_none():
+    buf = io.StringIO()
+    emit_result(None, json_mode=False, stream=buf)
+    assert buf.getvalue() == ""
+
+
+def test_emit_result_json_wraps_payload_in_ok_true():
+    buf = io.StringIO()
+    emit_result({"name": "FOO"}, json_mode=True, stream=buf)
+    payload = json.loads(buf.getvalue())
+    assert payload == {"ok": True, "name": "FOO"}

--- a/tests/unit/test_fs.py
+++ b/tests/unit/test_fs.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import json
 import os
 import stat
-from pathlib import Path
-
-import pytest
 
 from shushu import fs
 

--- a/tests/unit/test_fs.py
+++ b/tests/unit/test_fs.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from shushu import fs
+
+
+def test_store_paths_respect_shushu_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
+    paths = fs.user_store_paths()
+    assert paths.dir == tmp_path / "shushu"
+    assert paths.file == tmp_path / "shushu" / "secrets.json"
+    assert paths.lock == tmp_path / "shushu" / ".lock"
+
+
+def test_store_paths_default_to_home_when_env_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("SHUSHU_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    paths = fs.user_store_paths()
+    assert paths.dir == tmp_path / ".local/share/shushu"
+
+
+def test_ensure_store_dir_creates_with_mode_0700(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
+    fs.ensure_store_dir()
+    st = (tmp_path / "shushu").stat()
+    assert stat.S_IMODE(st.st_mode) == 0o700
+
+
+def test_atomic_write_text_creates_file_with_mode_0600(tmp_path):
+    target = tmp_path / "secrets.json"
+    fs.atomic_write_text(target, '{"hello": "world"}\n')
+    assert target.read_text() == '{"hello": "world"}\n'
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_atomic_write_text_is_crash_safe(tmp_path):
+    """On rename, either the old content or the new content is visible.
+    Never a half-written file."""
+    target = tmp_path / "secrets.json"
+    target.write_text('{"v": 1}\n')
+    os.chmod(target, 0o600)
+    fs.atomic_write_text(target, '{"v": 2}\n')
+    assert json.loads(target.read_text()) == {"v": 2}
+    # Temp file must be cleaned up.
+    leftovers = [p for p in tmp_path.iterdir() if p.name.startswith("secrets.json.")]
+    assert leftovers == []
+
+
+def test_locked_write_acquires_exclusive_lock(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
+    fs.ensure_store_dir()
+    with fs.locked_write() as lock_fd:
+        assert lock_fd > 0  # valid fd

--- a/tests/unit/test_generate.py
+++ b/tests/unit/test_generate.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from shushu import generate
+
+
+def test_hex_default_length_is_64_chars_for_32_bytes():
+    s = generate.random_secret(nbytes=32, encoding="hex")
+    assert len(s) == 64
+    int(s, 16)  # must be valid hex
+
+
+def test_base64_round_trips():
+    s = generate.random_secret(nbytes=32, encoding="base64")
+    decoded = base64.b64decode(s, validate=True)
+    assert len(decoded) == 32
+
+
+def test_rejects_unknown_encoding():
+    with pytest.raises(ValueError):
+        generate.random_secret(nbytes=16, encoding="morse")
+
+
+@pytest.mark.parametrize("n", [1, 8, 16, 32, 64])
+def test_variable_byte_lengths(n):
+    s = generate.random_secret(nbytes=n, encoding="hex")
+    assert len(s) == n * 2
+
+
+def test_rejects_zero_or_negative_bytes():
+    for n in (0, -1):
+        with pytest.raises(ValueError):
+            generate.random_secret(nbytes=n, encoding="hex")

--- a/tests/unit/test_privilege.py
+++ b/tests/unit/test_privilege.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+import shutil
+
+import pytest
+
+from shushu import privilege
+
+
+def test_require_root_passes_when_euid_is_zero(monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    privilege.require_root("set --user alice FOO v")  # no raise
+
+
+def test_require_root_raises_privilege_error_when_not_root(monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    with pytest.raises(privilege.PrivilegeError) as exc:
+        privilege.require_root("set --user alice FOO v")
+    assert "sudo" in exc.value.remediation
+    assert "shushu" in exc.value.remediation
+
+
+def test_sudo_invoker_falls_back_to_getuid_when_SUDO_USER_unset(monkeypatch):
+    monkeypatch.delenv("SUDO_USER", raising=False)
+    name = privilege.sudo_invoker()
+    assert name  # never empty
+
+
+def test_sudo_invoker_prefers_SUDO_USER_when_set(monkeypatch):
+    monkeypatch.setenv("SUDO_USER", "alice")
+    assert privilege.sudo_invoker() == "alice"
+
+
+def test_resolve_shushu_path_falls_back_to_plain_name(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    assert privilege.resolve_shushu_path() == "shushu"
+
+
+def test_resolve_shushu_path_uses_which_when_available(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _: "/home/alice/.local/bin/shushu")
+    assert privilege.resolve_shushu_path() == "/home/alice/.local/bin/shushu"

--- a/tests/unit/test_privilege.py
+++ b/tests/unit/test_privilege.py
@@ -21,13 +21,13 @@ def test_require_root_raises_privilege_error_when_not_root(monkeypatch):
     assert "shushu" in exc.value.remediation
 
 
-def test_sudo_invoker_falls_back_to_getuid_when_SUDO_USER_unset(monkeypatch):
+def test_sudo_invoker_falls_back_to_getuid_when_sudo_user_unset(monkeypatch):
     monkeypatch.delenv("SUDO_USER", raising=False)
     name = privilege.sudo_invoker()
     assert name  # never empty
 
 
-def test_sudo_invoker_prefers_SUDO_USER_when_set(monkeypatch):
+def test_sudo_invoker_prefers_sudo_user_when_set(monkeypatch):
     monkeypatch.setenv("SUDO_USER", "alice")
     assert privilege.sudo_invoker() == "alice"
 

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import pytest
+
+from shushu import store
+
+
+@pytest.fixture(autouse=True)
+def _tmp_store(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
+
+
+def test_load_returns_empty_when_no_file():
+    data = store.load()
+    assert data.schema_version == 1
+    assert data.secrets == []
+
+
+def test_set_then_load_roundtrips():
+    rec = store.set_secret(
+        name="FOO",
+        value="bar",
+        hidden=False,
+        source="localhost",
+        purpose="test",
+    )
+    assert rec.name == "FOO"
+    data = store.load()
+    assert len(data.secrets) == 1
+    assert data.secrets[0].name == "FOO"
+    assert data.secrets[0].value == "bar"
+
+
+def test_overwrite_silently_replaces_value():
+    store.set_secret(name="FOO", value="v1", hidden=False, source="localhost", purpose="")
+    store.set_secret(name="FOO", value="v2", hidden=False, source="localhost", purpose="")
+    data = store.load()
+    assert len(data.secrets) == 1
+    assert data.secrets[0].value == "v2"
+
+
+def test_overwrite_preserves_created_at_and_handed_over_by():
+    first = store.set_secret(name="FOO", value="v1", hidden=False, source="localhost", purpose="")
+    second = store.set_secret(name="FOO", value="v2", hidden=False, source="localhost", purpose="")
+    assert first.created_at == second.created_at
+    assert first.handed_over_by == second.handed_over_by
+
+
+def test_set_rejects_invalid_name():
+    with pytest.raises(store.ValidationError):
+        store.set_secret(
+            name="lowercase-bad",
+            value="v",
+            hidden=False,
+            source="localhost",
+            purpose="",
+        )
+
+
+def test_update_metadata_only():
+    store.set_secret(name="FOO", value="v", hidden=False, source="localhost", purpose="orig")
+    store.update_metadata(name="FOO", purpose="new")
+    data = store.load()
+    assert data.secrets[0].purpose == "new"
+    assert data.secrets[0].value == "v"  # untouched
+
+
+def test_update_metadata_rejects_immutable_fields():
+    store.set_secret(name="FOO", value="v", hidden=False, source="localhost", purpose="")
+    with pytest.raises(store.ValidationError):
+        store.update_metadata(name="FOO", source="forbidden")  # type: ignore[arg-type]
+
+
+def test_update_metadata_rejects_unknown_secret():
+    with pytest.raises(store.NotFoundError):
+        store.update_metadata(name="NOPE", purpose="x")
+
+
+def test_get_value_raises_on_hidden():
+    store.set_secret(name="SECRET", value="s", hidden=True, source="localhost", purpose="")
+    with pytest.raises(store.HiddenError):
+        store.get_value("SECRET")
+
+
+def test_get_value_returns_visible():
+    store.set_secret(name="VISIBLE", value="hello", hidden=False, source="localhost", purpose="")
+    assert store.get_value("VISIBLE") == "hello"
+
+
+def test_delete_removes_record():
+    store.set_secret(name="FOO", value="v", hidden=False, source="localhost", purpose="")
+    store.delete("FOO")
+    assert store.load().secrets == []
+
+
+def test_delete_missing_raises_not_found():
+    with pytest.raises(store.NotFoundError):
+        store.delete("NOPE")
+
+
+def test_list_names_sorted():
+    for n in ["BAZ", "FOO", "BAR"]:
+        store.set_secret(name=n, value="v", hidden=False, source="localhost", purpose="")
+    assert store.list_names() == ["BAR", "BAZ", "FOO"]
+
+
+def test_schema_version_mismatch_raises():
+    paths = store._paths()
+    paths.dir.mkdir(parents=True, exist_ok=True)
+    paths.file.write_text(json.dumps({"schema_version": 99, "secrets": []}))
+    with pytest.raises(store.StateError) as exc:
+        store.load()
+    assert "schema_version" in str(exc.value)
+
+
+def test_alert_at_parsed_and_stored():
+    store.set_secret(
+        name="FOO",
+        value="v",
+        hidden=False,
+        source="localhost",
+        purpose="",
+        alert_at=date(2030, 1, 1),
+    )
+    rec = store.load().secrets[0]
+    assert rec.alert_at == date(2030, 1, 1)

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -186,3 +186,41 @@ def test_utf8_roundtrip():
     )
     rec = store.load().secrets[0]
     assert rec.value == "pa$$wörd-日本語-🔑"
+
+
+def test_load_raw_rejects_non_list_secrets():
+    paths = store._paths()
+    paths.dir.mkdir(parents=True, exist_ok=True)
+    paths.file.write_text(json.dumps({"schema_version": 1, "secrets": None}))
+    with pytest.raises(store.StateError) as exc:
+        store.load()
+    assert "must be a list" in str(exc.value)
+
+
+def test_load_raw_rejects_non_bool_hidden():
+    paths = store._paths()
+    paths.dir.mkdir(parents=True, exist_ok=True)
+    paths.file.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "secrets": [
+                    {
+                        "name": "FOO",
+                        "value": "v",
+                        "hidden": "false",
+                        "source": "localhost",
+                        "purpose": "",
+                        "rotation_howto": "",
+                        "alert_at": None,
+                        "handed_over_by": None,
+                        "created_at": "2026-04-24T12:00:00Z",
+                        "updated_at": "2026-04-24T12:00:00Z",
+                    }
+                ],
+            }
+        )
+    )
+    with pytest.raises(store.StateError) as exc:
+        store.load()
+    assert "non-boolean hidden" in str(exc.value)

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -127,3 +127,62 @@ def test_alert_at_parsed_and_stored():
     )
     rec = store.load().secrets[0]
     assert rec.alert_at == date(2030, 1, 1)
+
+
+def test_set_secret_rejects_changing_source_on_overwrite():
+    store.set_secret(name="FOO", value="v1", hidden=False, source="localhost", purpose="")
+    with pytest.raises(store.ValidationError) as exc:
+        store.set_secret(
+            name="FOO", value="v2", hidden=False, source="https://elsewhere", purpose=""
+        )
+    assert "source is immutable" in str(exc.value)
+
+
+def test_set_secret_rejects_changing_hidden_on_overwrite():
+    store.set_secret(name="FOO", value="v1", hidden=False, source="localhost", purpose="")
+    with pytest.raises(store.ValidationError) as exc:
+        store.set_secret(name="FOO", value="v2", hidden=True, source="localhost", purpose="")
+    assert "hidden is immutable" in str(exc.value)
+
+
+def test_corrupt_json_raises_state_error():
+    paths = store._paths()
+    paths.dir.mkdir(parents=True, exist_ok=True)
+    paths.file.write_text("{ this is not json")
+    with pytest.raises(store.StateError) as exc:
+        store.load()
+    assert "JSON" in str(exc.value) or "json" in str(exc.value)
+
+
+def test_schema_version_as_string_raises_state_error():
+    paths = store._paths()
+    paths.dir.mkdir(parents=True, exist_ok=True)
+    paths.file.write_text(json.dumps({"schema_version": "1", "secrets": []}))
+    with pytest.raises(store.StateError) as exc:
+        store.load()
+    assert "non-integer schema_version" in str(exc.value)
+
+
+def test_set_secret_on_overwrite_with_empty_purpose_keeps_existing():
+    """Documented falsy-merge: set_secret(purpose='') on overwrite keeps prior purpose."""
+    store.set_secret(name="FOO", value="v1", hidden=False, source="localhost", purpose="orig")
+    store.set_secret(name="FOO", value="v2", hidden=False, source="localhost", purpose="")
+    rec = store.load().secrets[0]
+    assert rec.purpose == "orig"
+
+
+def test_update_metadata_empty_purpose_clears_existing():
+    """update_metadata distinguishes None (leave alone) from "" (clear)."""
+    store.set_secret(name="FOO", value="v", hidden=False, source="localhost", purpose="orig")
+    store.update_metadata(name="FOO", purpose="")
+    rec = store.load().secrets[0]
+    assert rec.purpose == ""
+
+
+def test_utf8_roundtrip():
+    """Arbitrary UTF-8 in values must survive serialization (spec §4.3)."""
+    store.set_secret(
+        name="UNICODE", value="pa$$wörd-日本語-🔑", hidden=False, source="localhost", purpose=""
+    )
+    rec = store.load().secrets[0]
+    assert rec.value == "pa$$wörd-日本語-🔑"

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -10,16 +10,16 @@ from shushu import users
 
 def test_current_returns_current_user_info():
     info = users.current()
-    expected_name = pwd.getpwuid(os.getuid()).pw_name
+    expected_name = pwd.getpwuid(os.geteuid()).pw_name
     assert info.name == expected_name
-    assert info.uid == os.getuid()
+    assert info.uid == os.geteuid()
 
 
 def test_resolve_known_user_returns_info():
-    expected_name = pwd.getpwuid(os.getuid()).pw_name
+    expected_name = pwd.getpwuid(os.geteuid()).pw_name
     info = users.resolve(expected_name)
     assert info.name == expected_name
-    assert info.uid == os.getuid()
+    assert info.uid == os.geteuid()
 
 
 def test_resolve_unknown_user_raises():

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+import pwd
+
+import pytest
+
+from shushu import users
+
+
+def test_current_returns_current_user_info():
+    info = users.current()
+    expected_name = pwd.getpwuid(os.getuid()).pw_name
+    assert info.name == expected_name
+    assert info.uid == os.getuid()
+
+
+def test_resolve_known_user_returns_info():
+    expected_name = pwd.getpwuid(os.getuid()).pw_name
+    info = users.resolve(expected_name)
+    assert info.name == expected_name
+    assert info.uid == os.getuid()
+
+
+def test_resolve_unknown_user_raises():
+    with pytest.raises(KeyError):
+        users.resolve("definitely-not-a-real-user-xxxxx")
+
+
+def test_all_users_returns_list_with_entries_having_home_and_name():
+    rows = users.all_users()
+    assert len(rows) >= 1
+    for info in rows:
+        assert isinstance(info.name, str)
+        assert isinstance(info.uid, int)

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "shushu"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "shushu"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Second batch of the shushu v1 implementation — Tasks 7–14 of the plan. This is the stdlib-only core: filesystem primitives, secret store with schema/immutability/locking, privilege handling (setuid-fork helper for admin handoff), CLI error discipline, and the argparse skeleton that lists every verb. No runtime verb behavior yet — every subcommand dispatches to a stub that exits 64 with "not implemented". Those handlers land in Tasks 15–25 (next PR batch).

### New modules

| Module | Role |
|---|---|
| `src/shushu/fs.py` | Paths, fcntl locking (LOCK_SH / LOCK_EX), atomic write-temp → fsync → rename. `SHUSHU_HOME` env override for tests. |
| `src/shushu/alerts.py` | UTC-based classification: `ok` / `alerting` (≤30 days) / `expired`. |
| `src/shushu/generate.py` | Random hex/base64 secrets via `secrets.token_bytes`. |
| `src/shushu/users.py` | `pwd`-backed `UserInfo` dataclass + `current` / `resolve` / `all_users`. |
| `src/shushu/privilege.py` | `PrivilegeError`, `require_root`, `sudo_invoker`, `resolve_shushu_path`, `run_as_user` (the fork + setgroups + setgid + setuid helper). |
| `src/shushu/store.py` | Schema-enforced JSON CRUD. Every mutation runs under a single `LOCK_EX` for the full read-mutate-atomic-write cycle (per design spec §4.5). Typed errors for the CLI layer. |
| `src/shushu/cli/_errors.py` | `ShushuError` + `EXIT_*` constants. |
| `src/shushu/cli/_output.py` | `emit_result` / `emit_error` / `emit_warning` with text-vs-JSON discipline. |

### CLI parser (Task 14)

`src/shushu/cli/__init__.py` now wires the full argparse surface:

```
$ shushu --help
usage: shushu [-h] [--version]
              {doctor,learn,explain,overview,set,show,get,env,run,generate,list,delete}
              ...
```

All 12 verbs parse their documented flags (per design §2.2). `--user` / `--all-users` admin flags are wired as a mutually-exclusive group on the verbs that accept them. Dispatch routes to stub handlers that raise `NotImplementedError`; `main()` catches and emits `EXIT_USER_ERROR` with "coming in a later task" remediation.

`main()` also centralizes exception→exit-code routing: `ShushuError` → its code; `store.{Validation,NotFound,Hidden,State}Error` → 64/64/64/65; `privilege.PrivilegeError` → 66; anything else → 70 with traceback to stderr.

### Correctness fixes applied during code review

- **Store lock atomicity.** Original Task 12 draft did `load()` (LOCK_SH) → release → `_save()` (LOCK_EX), leaving a race window between the read and write. Now every mutation holds `LOCK_EX` for the full read-mutate-write cycle.
- **Schema-version error clarity.** `"schema_version": "1"` (string) previously produced "schema_version=1 but supports 1" — misleading. Now a `isinstance(sv, int)` guard fires first with a distinct error.
- **Datetime parse errors.** A hand-edited `secrets.json` with microseconds previously exposed a `strptime` traceback. Now surfaces "non-canonical datetime; expected `YYYY-MM-DDTHH:MM:SSZ`".
- **`str(exc)` readability.** `ShushuError` and `PrivilegeError` pass only `message` to `super().__init__()` so `str(exc)` stays human-readable; `remediation` lives as an attribute. B042 silenced locally with rationale comments.

### What's NOT in this PR

- No verb handlers yet (Tasks 15–25: `set`, `generate`, `get`, `env`, `run`, `show`, `list`, `delete`, `doctor`, `overview`, `learn`, `explain`).
- No admin mode (`--user` / `--all-users` routing through `privilege.run_as_user`) — that's Task 26.
- No integration tests (Task 26) or self-verify lifecycle (Task 27).
- No fleshed-out docs or README rewrite (Task 28).

## Test plan

- [x] `uv run pytest tests/` → 62 passed.
- [x] `uv run flake8 src/shushu tests` → clean.
- [x] `uv run black --check src/shushu tests` → clean.
- [x] `uv run shushu --version` → `shushu 0.3.0`.
- [x] `uv run shushu --help` → lists all 12 verbs.
- [x] `uv run shushu doctor` → exits 64 with "not implemented: doctor: implemented in Task 16".
- [x] `scripts/lint-md.sh` → 0 errors.
- [ ] GitHub Actions green (check on PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)