### PR TITLE
Read-only verb handlers (Tasks 15–17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ with merged PRs per the per-PR version bump discipline documented in
 
 ## [Unreleased]
 
-- (nothing yet — v0.3.1 cut; next bump on the following PR)
+- (nothing yet — v0.4.0 cut; next bump on the following PR)
+
+## [0.4.0] — 2026-04-25
+
+### Added
+
+- `shushu learn` — agent-authored self-teaching output. Text mode prints a markdown summary of every verb and concept; `--json` returns a structured payload (`verbs`, `descriptions`, `concepts`) for machine consumers.
+- `shushu explain <topic>` — short markdown body per topic. Topics include every verb plus the conceptual entries `hidden`, `admin`, `alert_at`. Unknown topics exit 64 with a `try: ...` remediation hint.
+- `shushu doctor` — read-only setup / permission / schema integrity checks against the invoker's own store. Verifies store dir mode (`0o700`), secrets file mode (`0o600`), `schema_version`, and per-record validity (empty `purpose` / `rotation_howto`, expired or alerting `alert_at`). Text mode prints `[STATUS] name: detail` per check + a summary line; `--json` returns `{checks: [...], summary: {pass, warn, fail}}`. Exit 0 unless any FAIL (then `EXIT_STATE` = 65). `--user` / `--all-users` raise a `not yet implemented` error pending Task 26.
+- `shushu overview` — rich metadata snapshot of every secret in the invoker's store with alert classification (`ok` / `alerting` / `expired`). `--expired` filters to expired records only; `--json` returns the full structured payload. **Never prints `value`.** `--user` / `--all-users` raise a `not yet implemented` error pending Task 26.
+
+### Tests
+
+- 11 new unit tests covering the `learn`, `explain`, `doctor`, and `overview` verbs end-to-end. Total: 77 tests passing.
 
 ## [0.3.1] — 2026-04-24
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shushu"
-version = "0.3.1"
+version = "0.4.0"
 description = "shushu CLI"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/shushu/cli/__init__.py
+++ b/src/shushu/cli/__init__.py
@@ -58,9 +58,9 @@ def _build_parser() -> argparse.ArgumentParser:
     sub = p.add_subparsers(dest="cmd")
 
     # globals
-    sub.add_parser("doctor", help="Store health / integrity checks").add_argument(
-        "--json", action="store_true"
-    )
+    pdoc = sub.add_parser("doctor", help="Store health / integrity checks")
+    pdoc.add_argument("--json", action="store_true")
+    _add_admin_flags(pdoc)
     sub.add_parser("learn", help="Agent-authored self-teaching output").add_argument(
         "--json", action="store_true"
     )

--- a/src/shushu/cli/_commands/doctor.py
+++ b/src/shushu/cli/_commands/doctor.py
@@ -1,5 +1,112 @@
+"""`shushu doctor` — store / permission / schema integrity."""
+
 from __future__ import annotations
+
+import stat as stat_
+
+from shushu import alerts, fs, store
+from shushu.cli._errors import EXIT_STATE, ShushuError
+from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
-    raise NotImplementedError("doctor: implemented in Task 16")
+    json_mode = args.json
+    # Admin variants (--user / --all-users) are wired in Task 26.
+    if getattr(args, "user", None) or getattr(args, "all_users", False):
+        raise ShushuError(
+            66,
+            "doctor --user / --all-users not yet implemented",
+            "coming in Task 26",
+        )
+    report = _run_self_checks()
+    payload = {"checks": report, "summary": _summarize(report)}
+    if json_mode:
+        emit_result(payload, json_mode=True)
+    else:
+        for c in report:
+            print(f"[{c['status']}] {c['name']}: {c['detail']}")
+        s = payload["summary"]
+        print(f"pass={s['pass']} warn={s['warn']} fail={s['fail']}")
+    return 0 if payload["summary"]["fail"] == 0 else EXIT_STATE
+
+
+def _run_self_checks():
+    paths = fs.user_store_paths()
+    checks = []
+
+    # 1. store dir
+    if not paths.dir.exists():
+        checks.append({"name": "store_dir", "status": "PASS", "detail": "no store yet (lazy init)"})
+    else:
+        mode = stat_.S_IMODE(paths.dir.stat().st_mode)
+        if mode != 0o700:
+            checks.append(
+                {
+                    "name": "store_dir_mode",
+                    "status": "WARN",
+                    "detail": f"{paths.dir} mode {oct(mode)}; expected 0o700",
+                }
+            )
+        else:
+            checks.append({"name": "store_dir", "status": "PASS", "detail": str(paths.dir)})
+
+    # 2. file + schema
+    if paths.file.exists():
+        mode = stat_.S_IMODE(paths.file.stat().st_mode)
+        if mode != 0o600:
+            checks.append(
+                {
+                    "name": "secrets_file_mode",
+                    "status": "WARN",
+                    "detail": f"{paths.file} mode {oct(mode)}; expected 0o600",
+                }
+            )
+        try:
+            data = store.load()
+            checks.append(
+                {"name": "schema_version", "status": "PASS", "detail": f"v{data.schema_version}"}
+            )
+        except store.StateError as exc:
+            checks.append({"name": "schema_version", "status": "FAIL", "detail": str(exc)})
+            return checks
+    else:
+        data = store.StoreData(schema_version=1, secrets=[])
+        checks.append({"name": "schema_version", "status": "PASS", "detail": "empty store"})
+
+    # 3. per-record checks
+    for r in data.secrets:
+        if not r.purpose:
+            detail = f"{r.name} has empty purpose; consider `shushu set {r.name} --purpose '...'`"
+            checks.append({"name": "purpose", "status": "WARN", "detail": detail})
+        if not r.rotation_howto:
+            detail = (
+                f"{r.name} has empty rotation_howto;"
+                f" consider `shushu set {r.name} --rotate-howto '...'`"
+            )
+            checks.append({"name": "rotation_howto", "status": "WARN", "detail": detail})
+        state = alerts.classify(r.alert_at)
+        if state == "expired":
+            checks.append(
+                {
+                    "name": "alert_at",
+                    "status": "WARN",
+                    "detail": f"{r.name} alert_at={r.alert_at} is expired",
+                }
+            )
+        elif state == "alerting":
+            checks.append(
+                {
+                    "name": "alert_at",
+                    "status": "WARN",
+                    "detail": f"{r.name} alert_at={r.alert_at} is within 30 days",
+                }
+            )
+    return checks
+
+
+def _summarize(checks):
+    return {
+        "pass": sum(1 for c in checks if c["status"] == "PASS"),
+        "warn": sum(1 for c in checks if c["status"] == "WARN"),
+        "fail": sum(1 for c in checks if c["status"] == "FAIL"),
+    }

--- a/src/shushu/cli/_commands/doctor.py
+++ b/src/shushu/cli/_commands/doctor.py
@@ -32,76 +32,95 @@ def handle(args) -> int:
 
 def _run_self_checks():
     paths = fs.user_store_paths()
-    checks = []
-
-    # 1. store dir
-    if not paths.dir.exists():
-        checks.append({"name": "store_dir", "status": "PASS", "detail": "no store yet (lazy init)"})
-    else:
-        mode = stat_.S_IMODE(paths.dir.stat().st_mode)
-        if mode != 0o700:
-            checks.append(
-                {
-                    "name": "store_dir_mode",
-                    "status": "WARN",
-                    "detail": f"{paths.dir} mode {oct(mode)}; expected 0o700",
-                }
-            )
-        else:
-            checks.append({"name": "store_dir", "status": "PASS", "detail": str(paths.dir)})
-
-    # 2. file + schema
-    if paths.file.exists():
-        mode = stat_.S_IMODE(paths.file.stat().st_mode)
-        if mode != 0o600:
-            checks.append(
-                {
-                    "name": "secrets_file_mode",
-                    "status": "WARN",
-                    "detail": f"{paths.file} mode {oct(mode)}; expected 0o600",
-                }
-            )
-        try:
-            data = store.load()
-            checks.append(
-                {"name": "schema_version", "status": "PASS", "detail": f"v{data.schema_version}"}
-            )
-        except store.StateError as exc:
-            checks.append({"name": "schema_version", "status": "FAIL", "detail": str(exc)})
-            return checks
-    else:
-        data = store.StoreData(schema_version=1, secrets=[])
-        checks.append({"name": "schema_version", "status": "PASS", "detail": "empty store"})
-
-    # 3. per-record checks
-    for r in data.secrets:
-        if not r.purpose:
-            detail = f"{r.name} has empty purpose; consider `shushu set {r.name} --purpose '...'`"
-            checks.append({"name": "purpose", "status": "WARN", "detail": detail})
-        if not r.rotation_howto:
-            detail = (
-                f"{r.name} has empty rotation_howto;"
-                f" consider `shushu set {r.name} --rotate-howto '...'`"
-            )
-            checks.append({"name": "rotation_howto", "status": "WARN", "detail": detail})
-        state = alerts.classify(r.alert_at)
-        if state == "expired":
-            checks.append(
-                {
-                    "name": "alert_at",
-                    "status": "WARN",
-                    "detail": f"{r.name} alert_at={r.alert_at} is expired",
-                }
-            )
-        elif state == "alerting":
-            checks.append(
-                {
-                    "name": "alert_at",
-                    "status": "WARN",
-                    "detail": f"{r.name} alert_at={r.alert_at} is within 30 days",
-                }
-            )
+    checks = [_check_store_dir(paths)]
+    data, file_checks, fatal = _check_secrets_file(paths)
+    checks.extend(file_checks)
+    if fatal:
+        return checks
+    for record in data.secrets:
+        checks.extend(_check_record(record))
     return checks
+
+
+def _check_store_dir(paths):
+    if not paths.dir.exists():
+        return {"name": "store_dir", "status": "PASS", "detail": "no store yet (lazy init)"}
+    mode = stat_.S_IMODE(paths.dir.stat().st_mode)
+    if mode != 0o700:
+        return {
+            "name": "store_dir_mode",
+            "status": "WARN",
+            "detail": f"{paths.dir} mode {oct(mode)}; expected 0o700",
+        }
+    return {"name": "store_dir", "status": "PASS", "detail": str(paths.dir)}
+
+
+def _check_secrets_file(paths):
+    """Return (data, checks, fatal). `fatal=True` means stop further checks."""
+    if not paths.file.exists():
+        empty = store.StoreData(schema_version=1, secrets=[])
+        return empty, [{"name": "schema_version", "status": "PASS", "detail": "empty store"}], False
+    checks = []
+    mode = stat_.S_IMODE(paths.file.stat().st_mode)
+    if mode != 0o600:
+        checks.append(
+            {
+                "name": "secrets_file_mode",
+                "status": "WARN",
+                "detail": f"{paths.file} mode {oct(mode)}; expected 0o600",
+            }
+        )
+    try:
+        data = store.load()
+    except store.StateError as exc:
+        checks.append({"name": "schema_version", "status": "FAIL", "detail": str(exc)})
+        return None, checks, True
+    checks.append({"name": "schema_version", "status": "PASS", "detail": f"v{data.schema_version}"})
+    return data, checks, False
+
+
+def _check_record(record):
+    out = []
+    if not record.purpose:
+        out.append(
+            {
+                "name": "purpose",
+                "status": "WARN",
+                "detail": (
+                    f"{record.name} has empty purpose;"
+                    f" consider `shushu set {record.name} --purpose '...'`"
+                ),
+            }
+        )
+    if not record.rotation_howto:
+        out.append(
+            {
+                "name": "rotation_howto",
+                "status": "WARN",
+                "detail": (
+                    f"{record.name} has empty rotation_howto;"
+                    f" consider `shushu set {record.name} --rotate-howto '...'`"
+                ),
+            }
+        )
+    state = alerts.classify(record.alert_at)
+    if state == "expired":
+        out.append(
+            {
+                "name": "alert_at",
+                "status": "WARN",
+                "detail": f"{record.name} alert_at={record.alert_at} is expired",
+            }
+        )
+    elif state == "alerting":
+        out.append(
+            {
+                "name": "alert_at",
+                "status": "WARN",
+                "detail": f"{record.name} alert_at={record.alert_at} is within 30 days",
+            }
+        )
+    return out
 
 
 def _summarize(checks):

--- a/src/shushu/cli/_commands/doctor.py
+++ b/src/shushu/cli/_commands/doctor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import stat as stat_
 
 from shushu import alerts, fs, store
-from shushu.cli._errors import EXIT_STATE, ShushuError
+from shushu.cli._errors import EXIT_STATE, EXIT_USER_ERROR, ShushuError
 from shushu.cli._output import emit_result
 
 
@@ -14,7 +14,7 @@ def handle(args) -> int:
     # Admin variants (--user / --all-users) are wired in Task 26.
     if getattr(args, "user", None) or getattr(args, "all_users", False):
         raise ShushuError(
-            66,
+            EXIT_USER_ERROR,
             "doctor --user / --all-users not yet implemented",
             "coming in Task 26",
         )
@@ -45,7 +45,14 @@ def _run_self_checks():
 def _check_store_dir(paths):
     if not paths.dir.exists():
         return {"name": "store_dir", "status": "PASS", "detail": "no store yet (lazy init)"}
-    mode = stat_.S_IMODE(paths.dir.stat().st_mode)
+    try:
+        mode = stat_.S_IMODE(paths.dir.stat().st_mode)
+    except OSError as exc:
+        return {
+            "name": "store_dir",
+            "status": "FAIL",
+            "detail": f"could not stat {paths.dir}: {exc}",
+        }
     if mode != 0o700:
         return {
             "name": "store_dir_mode",
@@ -58,11 +65,25 @@ def _check_store_dir(paths):
 def _check_secrets_file(paths):
     """Return (data, checks, fatal). `fatal=True` means stop further checks."""
     if not paths.file.exists():
-        empty = store.StoreData(schema_version=1, secrets=[])
+        empty = store.StoreData(schema_version=store.SCHEMA_VERSION, secrets=[])
         return empty, [{"name": "schema_version", "status": "PASS", "detail": "empty store"}], False
     checks = []
-    mode = stat_.S_IMODE(paths.file.stat().st_mode)
-    if mode != 0o600:
+    try:
+        mode = stat_.S_IMODE(paths.file.stat().st_mode)
+    except OSError as exc:
+        checks.append(
+            {
+                "name": "secrets_file_mode",
+                "status": "FAIL",
+                "detail": f"could not stat {paths.file}: {exc}",
+            }
+        )
+        return None, checks, True
+    if mode == 0o600:
+        checks.append(
+            {"name": "secrets_file_mode", "status": "PASS", "detail": f"{paths.file} mode 0o600"}
+        )
+    else:
         checks.append(
             {
                 "name": "secrets_file_mode",
@@ -74,6 +95,15 @@ def _check_secrets_file(paths):
         data = store.load()
     except store.StateError as exc:
         checks.append({"name": "schema_version", "status": "FAIL", "detail": str(exc)})
+        return None, checks, True
+    except OSError as exc:
+        checks.append(
+            {
+                "name": "schema_version",
+                "status": "FAIL",
+                "detail": f"could not read {paths.file}: {exc}",
+            }
+        )
         return None, checks, True
     checks.append({"name": "schema_version", "status": "PASS", "detail": f"v{data.schema_version}"})
     return data, checks, False

--- a/src/shushu/cli/_commands/explain.py
+++ b/src/shushu/cli/_commands/explain.py
@@ -42,7 +42,7 @@ _TOPICS = {
         "`shushu list [--json] [--user NAME|--all-users]`\n\n"
         "Names only, one per line. Scriptable."
     ),
-    "delete": ("`shushu delete NAME`\n\n" "Remove a secret. No undo."),
+    "delete": "`shushu delete NAME`\n\nRemove a secret. No undo.",
     "overview": (
         "`shushu overview [--json] [--expired] [--user NAME|--all-users]`\n\n"
         "Rich metadata snapshot with alert classification."

--- a/src/shushu/cli/_commands/explain.py
+++ b/src/shushu/cli/_commands/explain.py
@@ -1,5 +1,84 @@
+"""`shushu explain <topic>` — short markdown docs per topic."""
+
 from __future__ import annotations
+
+from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
+from shushu.cli._output import emit_result
+
+_TOPICS = {
+    "set": (
+        "`shushu set NAME [value] [--flags]`\n\n"
+        "Create or update. With value: writes value + metadata. Without value: updates mutable"
+        " metadata only (`--purpose`, `--rotate-howto`, `--alert-at`). `source` and `hidden`"
+        " are immutable post-create. Use `-` for value to read from stdin (preferred for real"
+        " secrets)."
+    ),
+    "show": (
+        "`shushu show NAME [--json]`\n\n"
+        "Print metadata (name, source, purpose, rotation_howto, alert_at, hidden,"
+        " handed_over_by, timestamps). Never prints `value`."
+    ),
+    "get": (
+        "`shushu get NAME`\n\n"
+        "Print value to stdout. Refuses if the secret is hidden"
+        " (use `shushu run --inject`)."
+    ),
+    "env": (
+        "`shushu env NAME1 [NAME2 ...]`\n\n"
+        "Print POSIX shell export lines for `eval $(shushu env FOO BAR)`."
+        " Refuses if any named secret is hidden."
+    ),
+    "run": (
+        "`shushu run --inject VAR=NAME [--inject ...] -- cmd [args...]`\n\n"
+        "Fork, set env vars from the store, `execvp` the command."
+        " Works for hidden and non-hidden."
+    ),
+    "generate": (
+        "`shushu generate NAME [--bytes N] [--encoding hex|base64] [flags]`\n\n"
+        "Create a random secret. Defaults to 32 bytes hex."
+        " `--hidden` → never prints value."
+    ),
+    "list": (
+        "`shushu list [--json] [--user NAME|--all-users]`\n\n"
+        "Names only, one per line. Scriptable."
+    ),
+    "delete": ("`shushu delete NAME`\n\n" "Remove a secret. No undo."),
+    "overview": (
+        "`shushu overview [--json] [--expired] [--user NAME|--all-users]`\n\n"
+        "Rich metadata snapshot with alert classification."
+    ),
+    "doctor": (
+        "`shushu doctor [--json] [--user NAME|--all-users]`\n\n"
+        "Verify store dir, file modes, schema_version, and per-record validity."
+    ),
+    "hidden": (
+        "A *hidden* secret has `hidden: true`. It is immutable — you cannot toggle it."
+        " The CLI refuses to print its value via `get` or `env`; only `shushu run --inject`"
+        " can consume it. Note: the file is still plaintext on disk (mode 0600)."
+        " `hidden` is a CLI contract, not cryptography."
+    ),
+    "admin": (
+        "Admin mode is `sudo shushu <verb> --user NAME` (or `--all-users` for reads)."
+        " shushu forks, drops to the target user's uid/gid, then writes as that user."
+        " The target user owns the resulting file. Admin *cannot* read values through the CLI"
+        " — even for root. Use `sudo cat` for plaintext."
+    ),
+    "alert_at": (
+        "Optional ISO date (`YYYY-MM-DD`). `overview` classifies records as ok /"
+        " alerting (within 30 days) / expired."
+        " shushu never enforces expiry — the date is informational."
+    ),
+}
 
 
 def handle(args) -> int:
-    raise NotImplementedError("explain: implemented in Task 15")
+    topic = args.topic
+    body = _TOPICS.get(topic)
+    if body is None:
+        raise ShushuError(
+            EXIT_USER_ERROR,
+            f"no topic {topic!r}",
+            "try: shushu explain set | hidden | admin | alert_at (or any verb name)",
+        )
+    emit_result(body, json_mode=False)
+    return 0

--- a/src/shushu/cli/_commands/learn.py
+++ b/src/shushu/cli/_commands/learn.py
@@ -1,5 +1,55 @@
+"""`shushu learn` — agent-authored self-teaching output."""
+
 from __future__ import annotations
+
+from shushu.cli._output import emit_result
+
+_VERBS = {
+    "set": (
+        "Create or update a secret. With value: writes value + metadata."
+        " Without value: updates mutable metadata only."
+    ),
+    "show": "Print full metadata for a secret (never value).",
+    "get": "Print value to stdout. Refused if hidden.",
+    "env": "Emit shell export lines for eval. Refused if any named secret is hidden.",
+    "run": "Spawn a command with secrets injected as env vars. Works for hidden and non-hidden.",
+    "generate": (
+        "Create a random secret (hex or base64)." " --hidden to make it write-only-via-inject."
+    ),
+    "list": "Names only, one per line. Scriptable.",
+    "delete": "Remove a secret.",
+    "overview": "Rich metadata snapshot; alert classification; --expired filter.",
+    "doctor": "Setup / permission / schema integrity checks.",
+    "learn": "What you are reading.",
+    "explain": "Human-readable docs for a verb or concept (e.g. `shushu explain hidden`).",
+}
+
+_CONCEPTS = [
+    "Hidden secrets can only be consumed via `shushu run --inject`. get/env refuse them.",
+    (
+        "Admin mode: `sudo shushu <verb> --user <name>` writes into another user's store"
+        " via setuid-fork."
+    ),
+    "The CLI never prints values in admin mode — even for root. Use `sudo cat` for plaintext.",
+    "Every destructive op is silent-overwrite; there is no rollback in v1.",
+    "alert_at is informational — shushu never deletes or refuses based on it.",
+]
 
 
 def handle(args) -> int:
-    raise NotImplementedError("learn: implemented in Task 15")
+    if args.json:
+        emit_result(
+            {"verbs": sorted(_VERBS.keys()), "descriptions": _VERBS, "concepts": _CONCEPTS},
+            json_mode=True,
+        )
+        return 0
+    lines = ["# shushu — agent-first per-OS-user secrets manager", ""]
+    lines.append("## Verbs")
+    for verb in sorted(_VERBS):
+        lines.append(f"- `{verb}` — {_VERBS[verb]}")
+    lines.append("")
+    lines.append("## Concepts")
+    for c in _CONCEPTS:
+        lines.append(f"- {c}")
+    emit_result("\n".join(lines), json_mode=False)
+    return 0

--- a/src/shushu/cli/_commands/learn.py
+++ b/src/shushu/cli/_commands/learn.py
@@ -13,9 +13,7 @@ _VERBS = {
     "get": "Print value to stdout. Refused if hidden.",
     "env": "Emit shell export lines for eval. Refused if any named secret is hidden.",
     "run": "Spawn a command with secrets injected as env vars. Works for hidden and non-hidden.",
-    "generate": (
-        "Create a random secret (hex or base64)." " --hidden to make it write-only-via-inject."
-    ),
+    "generate": "Create a random secret (hex or base64). --hidden hides value from print.",
     "list": "Names only, one per line. Scriptable.",
     "delete": "Remove a secret.",
     "overview": "Rich metadata snapshot; alert classification; --expired filter.",
@@ -36,20 +34,29 @@ _CONCEPTS = [
 ]
 
 
-def handle(args) -> int:
-    if args.json:
-        emit_result(
-            {"verbs": sorted(_VERBS.keys()), "descriptions": _VERBS, "concepts": _CONCEPTS},
-            json_mode=True,
-        )
-        return 0
-    lines = ["# shushu — agent-first per-OS-user secrets manager", ""]
-    lines.append("## Verbs")
+def _format_text() -> str:
+    lines = [
+        "# shushu — agent-first per-OS-user secrets manager",
+        "",
+        "## Verbs",
+    ]
     for verb in sorted(_VERBS):
         lines.append(f"- `{verb}` — {_VERBS[verb]}")
     lines.append("")
     lines.append("## Concepts")
-    for c in _CONCEPTS:
-        lines.append(f"- {c}")
-    emit_result("\n".join(lines), json_mode=False)
+    for concept in _CONCEPTS:
+        lines.append(f"- {concept}")
+    return "\n".join(lines)
+
+
+def handle(args) -> int:
+    if args.json:
+        payload = {
+            "verbs": sorted(_VERBS.keys()),
+            "descriptions": _VERBS,
+            "concepts": _CONCEPTS,
+        }
+        emit_result(payload, json_mode=True)
+    else:
+        emit_result(_format_text(), json_mode=False)
     return 0

--- a/src/shushu/cli/_commands/overview.py
+++ b/src/shushu/cli/_commands/overview.py
@@ -1,5 +1,50 @@
+"""`shushu overview` — rich metadata snapshot with alert classification."""
+
 from __future__ import annotations
+
+from shushu import alerts, store
+from shushu.cli._errors import ShushuError
+from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
-    raise NotImplementedError("overview: implemented in Task 17")
+    if getattr(args, "user", None) or getattr(args, "all_users", False):
+        raise ShushuError(
+            66,
+            "overview --user / --all-users not yet implemented",
+            "coming in Task 26",
+        )
+    data = store.load()
+    records = []
+    for r in data.secrets:
+        state = alerts.classify(r.alert_at)
+        if args.expired and state != "expired":
+            continue
+        records.append(
+            {
+                "name": r.name,
+                "hidden": r.hidden,
+                "source": r.source,
+                "purpose": r.purpose,
+                "rotation_howto": r.rotation_howto,
+                "alert_at": r.alert_at.isoformat() if r.alert_at else None,
+                "alert_state": state,
+                "handed_over_by": r.handed_over_by,
+                "created_at": r.created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "updated_at": r.updated_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+        )
+    if args.json:
+        emit_result({"secrets": records}, json_mode=True)
+    else:
+        if not records:
+            print("(no secrets)")
+        for r in records:
+            flags = []
+            if r["hidden"]:
+                flags.append("hidden")
+            if r["alert_state"] != "ok":
+                flags.append(r["alert_state"])
+            tag = f"  [{','.join(flags)}]" if flags else ""
+            print(f"{r['name']}{tag}  source={r['source']}  purpose={r['purpose']!r}")
+    return 0

--- a/src/shushu/cli/_commands/overview.py
+++ b/src/shushu/cli/_commands/overview.py
@@ -2,19 +2,23 @@
 
 from __future__ import annotations
 
-from shushu import alerts, store
-from shushu.cli._errors import ShushuError
+from shushu import alerts, fs, store
+from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
     if getattr(args, "user", None) or getattr(args, "all_users", False):
         raise ShushuError(
-            66,
+            EXIT_USER_ERROR,
             "overview --user / --all-users not yet implemented",
             "coming in Task 26",
         )
-    data = store.load()
+    # Read-only: don't trigger store-dir creation if no store exists yet.
+    if not fs.user_store_paths().file.exists():
+        data = store.StoreData(schema_version=store.SCHEMA_VERSION, secrets=[])
+    else:
+        data = store.load()
     records = []
     for record in data.secrets:
         state = alerts.classify(record.alert_at)

--- a/src/shushu/cli/_commands/overview.py
+++ b/src/shushu/cli/_commands/overview.py
@@ -16,35 +16,43 @@ def handle(args) -> int:
         )
     data = store.load()
     records = []
-    for r in data.secrets:
-        state = alerts.classify(r.alert_at)
+    for record in data.secrets:
+        state = alerts.classify(record.alert_at)
         if args.expired and state != "expired":
             continue
-        records.append(
-            {
-                "name": r.name,
-                "hidden": r.hidden,
-                "source": r.source,
-                "purpose": r.purpose,
-                "rotation_howto": r.rotation_howto,
-                "alert_at": r.alert_at.isoformat() if r.alert_at else None,
-                "alert_state": state,
-                "handed_over_by": r.handed_over_by,
-                "created_at": r.created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "updated_at": r.updated_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            }
-        )
+        records.append(_record_to_dict(record, state))
     if args.json:
         emit_result({"secrets": records}, json_mode=True)
     else:
-        if not records:
-            print("(no secrets)")
-        for r in records:
-            flags = []
-            if r["hidden"]:
-                flags.append("hidden")
-            if r["alert_state"] != "ok":
-                flags.append(r["alert_state"])
-            tag = f"  [{','.join(flags)}]" if flags else ""
-            print(f"{r['name']}{tag}  source={r['source']}  purpose={r['purpose']!r}")
+        _render_text(records)
     return 0
+
+
+def _record_to_dict(record, state):
+    return {
+        "name": record.name,
+        "hidden": record.hidden,
+        "source": record.source,
+        "purpose": record.purpose,
+        "rotation_howto": record.rotation_howto,
+        "alert_at": record.alert_at.isoformat() if record.alert_at else None,
+        "alert_state": state,
+        "handed_over_by": record.handed_over_by,
+        "created_at": record.created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "updated_at": record.updated_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+def _render_text(records):
+    if not records:
+        print("(no secrets)")
+        return
+    for record in records:
+        flags = []
+        if record["hidden"]:
+            flags.append("hidden")
+        if record["alert_state"] != "ok":
+            flags.append(record["alert_state"])
+        tag = f"  [{','.join(flags)}]" if flags else ""
+        name, source, purpose = record["name"], record["source"], record["purpose"]
+        print(f"{name}{tag}  source={source}  purpose={purpose!r}")

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -23,7 +23,7 @@ def _run(argv):
 
 
 def test_doctor_empty_store_reports_pass():
-    rc, out, _ = _run(["doctor", "--json"])
+    _, out, _ = _run(["doctor", "--json"])
     payload = json.loads(out)
     assert payload["ok"] is True
     assert payload["summary"]["fail"] == 0
@@ -31,7 +31,7 @@ def test_doctor_empty_store_reports_pass():
 
 def test_doctor_reports_warn_on_empty_purpose():
     store.set_secret(name="FOO", value="v", hidden=False, source="localhost", purpose="")
-    rc, out, _ = _run(["doctor", "--json"])
+    _, out, _ = _run(["doctor", "--json"])
     payload = json.loads(out)
     checks = payload["checks"]
     assert any(c["name"] == "purpose" and c["status"] == "WARN" for c in checks), checks
@@ -49,6 +49,6 @@ def test_doctor_reports_warn_on_expired_alert():
         rotation_howto="rotate",
     )
     store.update_metadata(name="OLD", alert_at=datetime.date(1990, 1, 1))
-    rc, out, _ = _run(["doctor", "--json"])
+    _, out, _ = _run(["doctor", "--json"])
     payload = json.loads(out)
     assert any(c["name"] == "alert_at" and c["status"] == "WARN" for c in payload["checks"])

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+
+from shushu import store
+from shushu.cli import main
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def test_doctor_empty_store_reports_pass():
+    rc, out, _ = _run(["doctor", "--json"])
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    assert payload["summary"]["fail"] == 0
+
+
+def test_doctor_reports_warn_on_empty_purpose():
+    store.set_secret(name="FOO", value="v", hidden=False, source="localhost", purpose="")
+    rc, out, _ = _run(["doctor", "--json"])
+    payload = json.loads(out)
+    checks = payload["checks"]
+    assert any(c["name"] == "purpose" and c["status"] == "WARN" for c in checks), checks
+
+
+def test_doctor_reports_warn_on_expired_alert():
+    import datetime
+
+    store.set_secret(
+        name="OLD",
+        value="v",
+        hidden=False,
+        source="localhost",
+        purpose="x",
+        rotation_howto="rotate",
+    )
+    store.update_metadata(name="OLD", alert_at=datetime.date(1990, 1, 1))
+    rc, out, _ = _run(["doctor", "--json"])
+    payload = json.loads(out)
+    assert any(c["name"] == "alert_at" and c["status"] == "WARN" for c in payload["checks"])

--- a/tests/unit/test_cli_globals.py
+++ b/tests/unit/test_cli_globals.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+
+from shushu.cli import main
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def test_learn_text_mentions_every_verb():
+    rc, out, _ = _run(["learn"])
+    assert rc == 0
+    expected = [
+        "set",
+        "show",
+        "get",
+        "env",
+        "run",
+        "generate",
+        "list",
+        "delete",
+        "overview",
+        "doctor",
+    ]
+    for verb in expected:
+        assert verb in out
+
+
+def test_learn_json_returns_ok_true_and_verb_index():
+    rc, out, _ = _run(["learn", "--json"])
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    assert "verbs" in payload
+    required = {
+        "set",
+        "show",
+        "get",
+        "env",
+        "run",
+        "generate",
+        "list",
+        "delete",
+        "overview",
+        "doctor",
+    }
+    assert set(payload["verbs"]) >= required
+
+
+def test_explain_known_verb_returns_markdown():
+    rc, out, _ = _run(["explain", "set"])
+    assert rc == 0
+    assert "set" in out.lower()
+
+
+def test_explain_known_concept():
+    rc, out, _ = _run(["explain", "hidden"])
+    assert rc == 0
+    assert "hidden" in out.lower()
+
+
+def test_explain_unknown_topic_is_user_error():
+    rc, _, err = _run(["explain", "definitely-not-a-topic"])
+    assert rc == 64
+    assert "definitely-not-a-topic" in err

--- a/tests/unit/test_cli_overview.py
+++ b/tests/unit/test_cli_overview.py
@@ -39,7 +39,7 @@ def test_overview_expired_filter():
     store.set_secret(name="A", value="v", hidden=False, source="localhost", purpose="x")
     store.set_secret(name="B", value="v", hidden=False, source="localhost", purpose="x")
     store.update_metadata(name="A", alert_at=date(1990, 1, 1))
-    rc, out = _run(["overview", "--expired", "--json"])
+    _, out = _run(["overview", "--expired", "--json"])
     payload = json.loads(out)
     names = {r["name"] for r in payload["secrets"]}
     assert names == {"A"}

--- a/tests/unit/test_cli_overview.py
+++ b/tests/unit/test_cli_overview.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+from datetime import date
+
+import pytest
+
+from shushu import store
+from shushu.cli import main
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
+
+
+def _run(argv):
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(argv)
+    return rc, buf.getvalue()
+
+
+def test_overview_json_includes_metadata_but_not_value():
+    store.set_secret(name="FOO", value="secret123", hidden=False, source="localhost", purpose="t")
+    rc, out = _run(["overview", "--json"])
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    rec = payload["secrets"][0]
+    assert rec["name"] == "FOO"
+    assert "value" not in rec
+    assert "secret123" not in out
+
+
+def test_overview_expired_filter():
+    store.set_secret(name="A", value="v", hidden=False, source="localhost", purpose="x")
+    store.set_secret(name="B", value="v", hidden=False, source="localhost", purpose="x")
+    store.update_metadata(name="A", alert_at=date(1990, 1, 1))
+    rc, out = _run(["overview", "--expired", "--json"])
+    payload = json.loads(out)
+    names = {r["name"] for r in payload["secrets"]}
+    assert names == {"A"}
+
+
+def test_overview_text_form_shows_alert_markers():
+    store.set_secret(name="A", value="v", hidden=False, source="localhost", purpose="x")
+    store.update_metadata(name="A", alert_at=date(1990, 1, 1))
+    rc, out = _run(["overview"])
+    assert rc == 0
+    assert "A" in out
+    assert "expired" in out.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "shushu"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Replaces the `NotImplementedError` stubs for the four read-only verbs in the
self-mode-only surface. No store mutations, no admin-mode code paths, no
new dependencies.

| Task | Verb | Notes |
|---|---|---|
| 15 | `learn` + `explain` | Static text + JSON payload of all verbs and concepts; per-topic markdown explanations. Unknown topic exits 64 with remediation. |
| 16 | `doctor` (self only) | Read-only checks on store dir mode (0o700), file mode (0o600), `schema_version`, and per-record `purpose` / `rotation_howto` / `alert_at`. Pass/warn/fail per check; exit 0 unless any FAIL. |
| 17 | `overview` (self only) | Rich metadata snapshot with alert classification (`ok` / `alerting` / `expired`); `--expired` filter; `--json` payload. **Never prints `value`.** |

Admin-mode wiring (`--user` / `--all-users`) for `doctor` and `overview` is
deferred to **Task 26**, which also adds the Docker-gated integration tests.
The handlers explicitly raise a `not yet implemented` error if those flags
are passed.

Version bump: `0.3.1` → `0.4.0` (minor — first real verb behavior beyond
the parser-only `0.3.x` line).

## Test plan

- [x] `uv run pytest tests/ -v` — 77 passing (66 prior + 11 new)
- [x] `uv run flake8 src/shushu tests` — clean
- [x] `uv run black --check src/shushu tests` — clean
- [x] `uv run isort --check-only src/shushu tests` — clean
- [x] `uv run bandit -r src/shushu -c pyproject.toml` — clean
- [x] `uv run pylint --errors-only src/shushu` — clean
- [x] `scripts/lint-md.sh` — 0 errors
- [x] `uv run shushu --version` → `shushu 0.4.0`
- [x] `uv run shushu learn` (text + `--json`) — verified
- [x] `uv run shushu explain hidden` and unknown topic — verified
- [x] `uv run shushu doctor` (text + `--json`, empty store) — verified
- [x] `uv run shushu overview` (text + `--json` + `--expired`, empty store) — verified
- [ ] CI green (`tests` workflow ran on PR head)

## Out of scope

- Admin mode (`--user` / `--all-users`) for `doctor` / `overview` — Task 26
- Integration tests / Docker — Task 26
- `set` / `generate` / `show` / `get` / `env` / `run` / `list` / `delete` — PR #5 + #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude