### PR TITLE
Consumption verbs (Tasks 21–25)

### DIFF
--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -19,7 +19,15 @@ This script adds:
 - A `--clean` flag to wipe `/tmp/shushu-tests/` after the run regardless
   of outcome.
 - A `--clean-only` mode for one-shot cleanup without running anything.
+- A `--clean-smoke <name>` mode for wiping a single smoke namespace
+  (`/tmp/shushu-tests/smoke-<name>/`) without touching the rest.
+- A `--smoke-home <name>` mode that prints the canonical smoke path so
+  shells can do `SHUSHU_HOME="$(bash test.sh --smoke-home task22)"`
+  without anyone writing `/tmp/shushu-tests/smoke-task22` by hand.
 - Standard `--parallel` / `--coverage` / `--ci` / `--quick` modes.
+
+The smoke flags exist so manual smoke flows never need a direct
+`rm -rf` against `/tmp/shushu-tests/*`. Always go through the wrapper.
 
 ## Usage
 
@@ -51,8 +59,10 @@ bash .claude/skills/run-tests/scripts/test.sh -p --clean
 | `--coverage`   | `-c` | `--cov=shushu --cov-report=term` |
 | `--ci`         |      | parallel + coverage + xml + verbose (mirrors `.github/workflows/tests.yml`) |
 | `--quick`      | `-q` | quiet output, no coverage |
-| `--clean`      | `-k` | `rm -rf /tmp/shushu-tests/` after the run, regardless of pass/fail |
+| `--clean`      | `-k` | wipe `/tmp/shushu-tests/` after the run, regardless of pass/fail |
 | `--clean-only` |      | wipe `/tmp/shushu-tests/` and exit (no test run) |
+| `--clean-smoke NAME` |  | wipe `/tmp/shushu-tests/smoke-NAME/` only and exit |
+| `--smoke-home NAME` |   | print `/tmp/shushu-tests/smoke-NAME` and exit (use to set `SHUSHU_HOME`) |
 
 Extra positional arguments pass through to pytest verbatim
 (`-x` to stop on first failure, `-k "pattern"` to filter, etc.).

--- a/.claude/skills/run-tests/scripts/test.sh
+++ b/.claude/skills/run-tests/scripts/test.sh
@@ -45,8 +45,18 @@ while [[ $# -gt 0 ]]; do
         --quick|-q)       QUIET=1; shift ;;
         --clean|-k)       CLEAN=1; shift ;;
         --clean-only)     CLEAN_ONLY=1; shift ;;
-        --clean-smoke)    CLEAN_SMOKE="$2"; shift 2 ;;
-        --smoke-home)     SMOKE_HOME="$2"; shift 2 ;;
+        --clean-smoke)
+            if [[ $# -lt 2 || -z "${2-}" ]]; then
+                echo "[run-tests] error: --clean-smoke requires a NAME argument" >&2
+                exit 2
+            fi
+            CLEAN_SMOKE="$2"; shift 2 ;;
+        --smoke-home)
+            if [[ $# -lt 2 || -z "${2-}" ]]; then
+                echo "[run-tests] error: --smoke-home requires a NAME argument" >&2
+                exit 2
+            fi
+            SMOKE_HOME="$2"; shift 2 ;;
         --help|-h)
             sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
             exit 0 ;;
@@ -66,7 +76,10 @@ clean_smoke_namespace() {
     local name="$1"
     # Defensive: refuse names that try to escape the smoke namespace.
     case "$name" in
-        ""|*/*|..|.|*$'\n'*) echo "[run-tests] invalid smoke name: $name" >&2; return 2 ;;
+        ""|*/*|..|.|*$'\n'*)
+            echo "[run-tests] invalid smoke name: $name" >&2
+            return 2 ;;
+        *) ;;  # accepted name; fall through
     esac
     local target="$ROOT/smoke-$name"
     if [[ -d "$target" ]]; then
@@ -78,7 +91,10 @@ clean_smoke_namespace() {
 
 if [[ -n "$SMOKE_HOME" ]]; then
     case "$SMOKE_HOME" in
-        ""|*/*|..|.|*$'\n'*) echo "[run-tests] invalid smoke name: $SMOKE_HOME" >&2; exit 2 ;;
+        ""|*/*|..|.|*$'\n'*)
+            echo "[run-tests] invalid smoke name: $SMOKE_HOME" >&2
+            exit 2 ;;
+        *) ;;  # accepted name; fall through
     esac
     echo "$ROOT/smoke-$SMOKE_HOME"
     exit 0

--- a/.claude/skills/run-tests/scripts/test.sh
+++ b/.claude/skills/run-tests/scripts/test.sh
@@ -12,12 +12,17 @@
 #   --clean,       -k   Clean /tmp/shushu-tests/ AFTER the run, regardless of outcome
 #                       (default: pytest's tmp_path_retention_policy=failed keeps the
 #                        last 3 failed-test trees for inspection)
-#   --clean-only        Don't run anything — just rm -rf /tmp/shushu-tests/ and exit
+#   --clean-only        Don't run anything — just wipe /tmp/shushu-tests/ and exit
+#   --clean-smoke NAME  Don't run anything — wipe /tmp/shushu-tests/smoke-NAME/ and exit.
+#                       Spares manual `rm -rf` calls in shell smoke flows.
+#   --smoke-home NAME   Don't run anything — print /tmp/shushu-tests/smoke-NAME and exit.
+#                       Use as: SHUSHU_HOME="$(bash test.sh --smoke-home task22)" uv run shushu ...
 #
 # Extra args are passed through to pytest (e.g. -x, -k "pattern").
 #
 # pyproject.toml already pins --basetemp=/tmp/shushu-tests so EVERY tmp_path
-# allocation is rooted there. Cleanup is a single rm -rf away.
+# allocation is rooted there. Cleanup is one wrapper invocation away — never
+# write a direct `rm -rf` against /tmp/shushu-tests/* from a shell.
 
 set -euo pipefail
 
@@ -28,20 +33,24 @@ CI_MODE=""
 QUIET=""
 CLEAN=""
 CLEAN_ONLY=""
+CLEAN_SMOKE=""
+SMOKE_HOME=""
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --parallel|-p)  PARALLEL=1; shift ;;
-        --coverage|-c)  COVERAGE=1; shift ;;
-        --ci)           CI_MODE=1; shift ;;
-        --quick|-q)     QUIET=1; shift ;;
-        --clean|-k)     CLEAN=1; shift ;;
-        --clean-only)   CLEAN_ONLY=1; shift ;;
+        --parallel|-p)    PARALLEL=1; shift ;;
+        --coverage|-c)    COVERAGE=1; shift ;;
+        --ci)             CI_MODE=1; shift ;;
+        --quick|-q)       QUIET=1; shift ;;
+        --clean|-k)       CLEAN=1; shift ;;
+        --clean-only)     CLEAN_ONLY=1; shift ;;
+        --clean-smoke)    CLEAN_SMOKE="$2"; shift 2 ;;
+        --smoke-home)     SMOKE_HOME="$2"; shift 2 ;;
         --help|-h)
             sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
             exit 0 ;;
-        *)              EXTRA_ARGS+=("$1"); shift ;;
+        *)                EXTRA_ARGS+=("$1"); shift ;;
     esac
 done
 
@@ -52,6 +61,33 @@ cleanup() {
     fi
     return 0
 }
+
+clean_smoke_namespace() {
+    local name="$1"
+    # Defensive: refuse names that try to escape the smoke namespace.
+    case "$name" in
+        ""|*/*|..|.|*$'\n'*) echo "[run-tests] invalid smoke name: $name" >&2; return 2 ;;
+    esac
+    local target="$ROOT/smoke-$name"
+    if [[ -d "$target" ]]; then
+        rm -rf "$target"
+        echo "[run-tests] cleaned $target"
+    fi
+    return 0
+}
+
+if [[ -n "$SMOKE_HOME" ]]; then
+    case "$SMOKE_HOME" in
+        ""|*/*|..|.|*$'\n'*) echo "[run-tests] invalid smoke name: $SMOKE_HOME" >&2; exit 2 ;;
+    esac
+    echo "$ROOT/smoke-$SMOKE_HOME"
+    exit 0
+fi
+
+if [[ -n "$CLEAN_SMOKE" ]]; then
+    clean_smoke_namespace "$CLEAN_SMOKE"
+    exit 0
+fi
 
 if [[ -n "$CLEAN_ONLY" ]]; then
     cleanup

--- a/.flake8
+++ b/.flake8
@@ -3,4 +3,4 @@ max-line-length = 100
 extend-ignore = E203, W503
 exclude = .git,__pycache__,build,dist,.venv
 per-file-ignores =
-    tests/*:S101
+    tests/*:S101,S404,S603,S607

--- a/.flake8
+++ b/.flake8
@@ -3,4 +3,4 @@ max-line-length = 100
 extend-ignore = E203, W503
 exclude = .git,__pycache__,build,dist,.venv
 per-file-ignores =
-    tests/*:S101,S404,S603,S607
+    tests/*:S101

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,25 @@ with merged PRs per the per-PR version bump discipline documented in
 
 ## [Unreleased]
 
-- (nothing yet — v0.5.0 cut; next bump on the following PR)
+- (nothing yet — v0.6.0 cut; next bump on the following PR)
+
+## [0.6.0] — 2026-04-25
+
+### Added
+
+- `shushu get NAME [--json]` — print a secret's value to stdout. Refuses if `hidden=True` (HiddenError → exit 64 with remediation pointing at `shushu run --inject`). The `get` parser deliberately does NOT register `--user` / `--all-users`: admin can never extract values via the CLI (H2 hidden-secret contract).
+- `shushu env NAME1 [NAME2 ...]` — emit POSIX single-quoted `export` lines for `eval $(shushu env A B)`. Refuses **the whole call** if any named secret is hidden (atomicity — never a partial print before the error). Single-quote escaping round-trips through bash for arbitrary values (verified by `test_env_escapes_single_quotes_posix_safe`).
+- `shushu run --inject VAR=NAME [--inject ...] -- cmd [args...]` — `os.execvpe` the child process with secrets stamped into env. Both visible and hidden secrets are allowed (this is the only consumer for hidden ones). `--inject` parsing emits explicit per-case malform errors (missing `=`, empty VAR, empty NAME). Last-wins on duplicate VAR. Leading `--` after argparse REMAINDER is stripped. `FileNotFoundError` from execvpe → exit 64 with a "check PATH" hint.
+- `shushu list [--json] [--user NAME|--all-users]` — names only, sorted, one per line. `--json` emits `{"ok": true, "names": [...]}`. `--user` / `--all-users` raise structured `not yet implemented` (exit 64) pending Task 26.
+- `shushu delete NAME [--json] [--user NAME]` — remove a secret. NotFoundError → exit 64 via main()'s wrapping. `--user` deferred to Task 26.
+
+### Tooling
+
+- `.claude/skills/run-tests/scripts/test.sh` gained `--clean-smoke <name>` and `--smoke-home <name>` flags. Smoke flows now never need a manual `rm -rf` against `/tmp/shushu-tests/*`; the wrapper validates the namespace (rejects `..`, `/`, empty, etc.) before touching disk. Documented in `docs/testing.md` and the SKILL.md.
+
+### Tests
+
+- 19 new unit tests covering the 5 new verbs end-to-end (4 + 4 + 6 + 3 + 2). Total: 114 tests passing.
 
 ## [0.5.0] — 2026-04-25
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,20 +44,25 @@ mutation is scoped to the test via `monkeypatch`.
 When running ad-hoc `SHUSHU_HOME=...` smoke commands by hand from the
 shell — e.g., to verify a new verb in a fresh store — use the
 `/tmp/shushu-tests/smoke-<topic>/` namespace, NOT scattered top-level
-paths like `/tmp/shushu-pr5` or `/tmp/shushu-task18-smoke`. Pattern:
+paths like `/tmp/shushu-pr5` or `/tmp/shushu-task18-smoke`. Use the
+run-tests wrapper to get the path and to clean up; **never write a
+direct `rm -rf` against `/tmp/shushu-tests/*` by hand.**
 
 ```bash
-mkdir -p /tmp/shushu-tests
-SMOKE=/tmp/shushu-tests/smoke-task19
-rm -rf "$SMOKE"
+TEST_SH=.claude/skills/run-tests/scripts/test.sh
+SMOKE="$(bash $TEST_SH --smoke-home task22)"   # prints /tmp/shushu-tests/smoke-task22
+bash $TEST_SH --clean-smoke task22              # safe wipe, validated name
 SHUSHU_HOME="$SMOKE" uv run shushu generate KEY
 SHUSHU_HOME="$SMOKE" uv run shushu generate SEKRET --hidden
-rm -rf "$SMOKE"   # always clean up your own artifacts
+bash $TEST_SH --clean-smoke task22              # always clean up after
 ```
 
-Cleanup discipline: every smoke session begins with `rm -rf "$SMOKE"`
-and ends with the same. Then `rm -rf /tmp/shushu-tests/` is always a
-safe blast-radius reset for the whole project.
+The wrapper validates the namespace (rejects `..`, `/`, empty, etc.)
+so you can't accidentally point the rm at a parent directory.
+
+Cleanup discipline: every smoke session begins and ends with
+`--clean-smoke <name>`. For a full reset of all smoke + pytest
+artifacts at once: `bash $TEST_SH --clean-only`.
 
 ## `SHUSHU_DOCKER` integration gate
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shushu"
-version = "0.5.0"
+version = "0.6.0"
 description = "shushu CLI"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/shushu/cli/_commands/delete.py
+++ b/src/shushu/cli/_commands/delete.py
@@ -1,5 +1,22 @@
+"""`shushu delete NAME` — remove a secret."""
+
 from __future__ import annotations
+
+from shushu import store
+from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
+from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
-    raise NotImplementedError("delete: implemented in Task 25")
+    if getattr(args, "user", None):
+        raise ShushuError(
+            EXIT_USER_ERROR,
+            "delete --user not yet implemented",
+            "coming in Task 26",
+        )
+    store.delete(args.name)  # NotFoundError caught by main()
+    if args.json:
+        emit_result({"name": args.name, "deleted": True}, json_mode=True)
+    else:
+        print(f"shushu: deleted {args.name}")
+    return 0

--- a/src/shushu/cli/_commands/env.py
+++ b/src/shushu/cli/_commands/env.py
@@ -1,5 +1,27 @@
+"""`shushu env NAME1 [NAME2 ...]` — emit POSIX shell export lines."""
+
 from __future__ import annotations
+
+from shushu import store
+from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 
 
 def handle(args) -> int:
-    raise NotImplementedError("env: implemented in Task 22")
+    records = []
+    for name in args.names:
+        rec = store.get_record(name)  # NotFoundError caught by main()
+        if rec.hidden:
+            raise ShushuError(
+                EXIT_USER_ERROR,
+                f"{name} is hidden",
+                f"exclude it or use `shushu run --inject {name}={name} -- <cmd>`",
+            )
+        records.append(rec)
+    for rec in records:
+        print(f"export {rec.name}='{_posix_quote(rec.value)}'")
+    return 0
+
+
+def _posix_quote(value: str) -> str:
+    """POSIX single-quote-safe: replace embedded ' with '\\''."""
+    return value.replace("'", "'\\''")

--- a/src/shushu/cli/_commands/get.py
+++ b/src/shushu/cli/_commands/get.py
@@ -1,5 +1,15 @@
+"""`shushu get NAME` — print value (refuses hidden)."""
+
 from __future__ import annotations
+
+from shushu import store
+from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
-    raise NotImplementedError("get: implemented in Task 21")
+    value = store.get_value(args.name)  # HiddenError/NotFoundError caught by main()
+    if args.json:
+        emit_result({"name": args.name, "value": value}, json_mode=True)
+    else:
+        print(value)
+    return 0

--- a/src/shushu/cli/_commands/list_.py
+++ b/src/shushu/cli/_commands/list_.py
@@ -1,5 +1,23 @@
+"""`shushu list` — names only, one per line."""
+
 from __future__ import annotations
+
+from shushu import store
+from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
+from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
-    raise NotImplementedError("list: implemented in Task 24")
+    if getattr(args, "user", None) or getattr(args, "all_users", False):
+        raise ShushuError(
+            EXIT_USER_ERROR,
+            "list --user / --all-users not yet implemented",
+            "coming in Task 26",
+        )
+    names = store.list_names()
+    if args.json:
+        emit_result({"names": names}, json_mode=True)
+    else:
+        for n in names:
+            print(n)
+    return 0

--- a/src/shushu/cli/_commands/run.py
+++ b/src/shushu/cli/_commands/run.py
@@ -1,5 +1,74 @@
+"""`shushu run --inject VAR=NAME ... -- cmd [args]` — exec with env."""
+
 from __future__ import annotations
+
+import os
+
+from shushu import store
+from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 
 
 def handle(args) -> int:
-    raise NotImplementedError("run: implemented in Task 23")
+    cmd = _resolve_cmd(args.cmd_and_args or [])
+    env_add = _build_env(args.inject)
+    new_env = {**os.environ, **env_add}
+    try:
+        os.execvpe(cmd[0], cmd, new_env)  # nosec B606 — input from CLI  # noqa: S606
+    except FileNotFoundError as exc:
+        raise ShushuError(
+            EXIT_USER_ERROR,
+            f"command not found: {cmd[0]!r}",
+            "check PATH or use an absolute path",
+        ) from exc
+    return 0  # unreachable — execvpe replaces the process
+
+
+def _resolve_cmd(cmd_and_args):
+    if not cmd_and_args:
+        raise ShushuError(
+            EXIT_USER_ERROR,
+            "no command given after --",
+            "expected form: shushu run --inject VAR=NAME -- <cmd> [args...]",
+        )
+    # argparse.REMAINDER leaves the leading '--' in the list.
+    if cmd_and_args[0] == "--":
+        cmd_and_args = cmd_and_args[1:]
+    if not cmd_and_args:
+        raise ShushuError(
+            EXIT_USER_ERROR,
+            "no command given after --",
+            "expected form: shushu run --inject VAR=NAME -- <cmd>",
+        )
+    return cmd_and_args
+
+
+def _build_env(inject_specs):
+    env_add: dict[str, str] = {}
+    for spec in inject_specs:
+        var, name = _parse_inject(spec)
+        rec = store.get_record(name)  # NotFoundError caught by main()
+        env_add[var] = rec.value  # last-wins on duplicate var
+    return env_add
+
+
+def _parse_inject(spec: str) -> tuple[str, str]:
+    if "=" not in spec:
+        raise ShushuError(
+            EXIT_USER_ERROR,
+            f"malformed --inject {spec!r}: missing '='",
+            "expected form: VAR=NAME (e.g. --inject OPENAI_API_KEY=OPENAI_API_KEY)",
+        )
+    var, _, name = spec.partition("=")
+    if not var:
+        raise ShushuError(
+            EXIT_USER_ERROR,
+            f"malformed --inject {spec!r}: empty variable name",
+            "expected form: VAR=NAME",
+        )
+    if not name:
+        raise ShushuError(
+            EXIT_USER_ERROR,
+            f"malformed --inject {spec!r}: empty secret name",
+            "expected form: VAR=NAME",
+        )
+    return var, name

--- a/src/shushu/cli/_commands/run.py
+++ b/src/shushu/cli/_commands/run.py
@@ -20,6 +20,15 @@ def handle(args) -> int:
             f"command not found: {cmd[0]!r}",
             "check PATH or use an absolute path",
         ) from exc
+    except (OSError, ValueError) as exc:
+        # OSError covers PermissionError (not executable), ENOEXEC (bad
+        # shebang), exec format error, etc. ValueError covers empty /
+        # embedded-NUL key or value in env.
+        raise ShushuError(
+            EXIT_USER_ERROR,
+            f"failed to execute {cmd[0]!r}: {exc}",
+            "check executable bit, shebang, and that VAR / value contain no NUL bytes",
+        ) from exc
     return 0  # unreachable — execvpe replaces the process
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+"""Shared test fixtures for shushu's unit tests.
+
+`_tmp_home` is autouse so every test gets an isolated `SHUSHU_HOME`
+under pytest's `tmp_path`. `cli_run` returns a callable that invokes
+`shushu.cli.main` with stdout + stderr captured, so tests don't have
+to repeat the `redirect_stdout` / `StringIO` boilerplate.
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+
+from shushu.cli import main
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
+
+
+@pytest.fixture
+def cli_run():
+    """Invoke `shushu.cli.main` with captured stdout/stderr.
+
+    Returns a callable `_run(argv) -> (rc, stdout, stderr)`.
+
+    Note: this helper deliberately does NOT catch `SystemExit`. The only
+    path that raises it is argparse rejecting unknown args (exit 2) —
+    those tests should use `pytest.raises(SystemExit)` instead, so the
+    expected exit code is asserted explicitly rather than swallowed.
+    """
+
+    def _run(argv):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = main(argv)
+        return rc, out.getvalue(), err.getvalue()
+
+    return _run

--- a/tests/unit/test_cli_delete.py
+++ b/tests/unit/test_cli_delete.py
@@ -1,34 +1,16 @@
 from __future__ import annotations
 
-import io
-from contextlib import redirect_stderr, redirect_stdout
-
-import pytest
-
 from shushu import store
-from shushu.cli import main
 
 
-@pytest.fixture(autouse=True)
-def _tmp_home(monkeypatch, tmp_path):
-    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
-
-
-def _run(argv):
-    out, err = io.StringIO(), io.StringIO()
-    with redirect_stdout(out), redirect_stderr(err):
-        rc = main(argv)
-    return rc, out.getvalue(), err.getvalue()
-
-
-def test_delete_removes_record():
+def test_delete_removes_record(cli_run):
     store.set_secret(name="FOO", value="v", hidden=False, source="localhost", purpose="")
-    rc, _, _ = _run(["delete", "FOO"])
+    rc, _, _ = cli_run(["delete", "FOO"])
     assert rc == 0
     assert store.list_names() == []
 
 
-def test_delete_missing_is_user_error():
-    rc, _, err = _run(["delete", "NOPE"])
+def test_delete_missing_is_user_error(cli_run):
+    rc, _, err = cli_run(["delete", "NOPE"])
     assert rc == 64
     assert "NOPE" in err

--- a/tests/unit/test_cli_delete.py
+++ b/tests/unit/test_cli_delete.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+
+from shushu import store
+from shushu.cli import main
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def test_delete_removes_record():
+    store.set_secret(name="FOO", value="v", hidden=False, source="localhost", purpose="")
+    rc, _, _ = _run(["delete", "FOO"])
+    assert rc == 0
+    assert store.list_names() == []
+
+
+def test_delete_missing_is_user_error():
+    rc, _, err = _run(["delete", "NOPE"])
+    assert rc == 64
+    assert "NOPE" in err

--- a/tests/unit/test_cli_env.py
+++ b/tests/unit/test_cli_env.py
@@ -1,37 +1,20 @@
 from __future__ import annotations
 
-import io
 import subprocess  # noqa: S404
-from contextlib import redirect_stderr, redirect_stdout
-
-import pytest
 
 from shushu import store
-from shushu.cli import main
 
 
-@pytest.fixture(autouse=True)
-def _tmp_home(monkeypatch, tmp_path):
-    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
-
-
-def _run(argv):
-    out, err = io.StringIO(), io.StringIO()
-    with redirect_stdout(out), redirect_stderr(err):
-        rc = main(argv)
-    return rc, out.getvalue(), err.getvalue()
-
-
-def test_env_emits_single_quoted_exports():
+def test_env_emits_single_quoted_exports(cli_run):
     store.set_secret(name="FOO", value="hello", hidden=False, source="localhost", purpose="")
     store.set_secret(name="BAR", value="world", hidden=False, source="localhost", purpose="")
-    rc, out, _ = _run(["env", "FOO", "BAR"])
+    rc, out, _ = cli_run(["env", "FOO", "BAR"])
     assert rc == 0
     assert "export FOO='hello'" in out
     assert "export BAR='world'" in out
 
 
-def test_env_escapes_single_quotes_posix_safe():
+def test_env_escapes_single_quotes_posix_safe(cli_run):
     store.set_secret(
         name="TRICKY",
         value="it's \"quoted\" and 'risky'",
@@ -39,7 +22,7 @@ def test_env_escapes_single_quotes_posix_safe():
         source="localhost",
         purpose="",
     )
-    rc, out, _ = _run(["env", "TRICKY"])
+    rc, out, _ = cli_run(["env", "TRICKY"])
     assert rc == 0
     # Round-trip through bash. nosec — bash on PATH, args composed from a
     # value the test itself stores.
@@ -52,14 +35,14 @@ def test_env_escapes_single_quotes_posix_safe():
     assert result.stdout == "it's \"quoted\" and 'risky'"
 
 
-def test_env_refuses_when_any_name_is_hidden():
+def test_env_refuses_when_any_name_is_hidden(cli_run):
     store.set_secret(name="VIS", value="v", hidden=False, source="localhost", purpose="")
     store.set_secret(name="HID", value="h", hidden=True, source="localhost", purpose="")
-    rc, _, err = _run(["env", "VIS", "HID"])
+    rc, _, err = cli_run(["env", "VIS", "HID"])
     assert rc == 64
     assert "HID" in err
 
 
-def test_env_missing_name_is_user_error():
-    rc, _, _ = _run(["env", "NOPE"])
+def test_env_missing_name_is_user_error(cli_run):
+    rc, _, _ = cli_run(["env", "NOPE"])
     assert rc == 64

--- a/tests/unit/test_cli_env.py
+++ b/tests/unit/test_cli_env.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-import subprocess
+import subprocess  # noqa: S404
 from contextlib import redirect_stderr, redirect_stdout
 
 import pytest
@@ -41,8 +41,9 @@ def test_env_escapes_single_quotes_posix_safe():
     )
     rc, out, _ = _run(["env", "TRICKY"])
     assert rc == 0
-    # Round-trip through bash.
-    result = subprocess.run(
+    # Round-trip through bash. nosec — bash on PATH, args composed from a
+    # value the test itself stores.
+    result = subprocess.run(  # noqa: S603, S607
         ["bash", "-c", f'{out.strip()}; printf %s "$TRICKY"'],
         capture_output=True,
         text=True,

--- a/tests/unit/test_cli_env.py
+++ b/tests/unit/test_cli_env.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import io
+import subprocess
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+
+from shushu import store
+from shushu.cli import main
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def test_env_emits_single_quoted_exports():
+    store.set_secret(name="FOO", value="hello", hidden=False, source="localhost", purpose="")
+    store.set_secret(name="BAR", value="world", hidden=False, source="localhost", purpose="")
+    rc, out, _ = _run(["env", "FOO", "BAR"])
+    assert rc == 0
+    assert "export FOO='hello'" in out
+    assert "export BAR='world'" in out
+
+
+def test_env_escapes_single_quotes_posix_safe():
+    store.set_secret(
+        name="TRICKY",
+        value="it's \"quoted\" and 'risky'",
+        hidden=False,
+        source="localhost",
+        purpose="",
+    )
+    rc, out, _ = _run(["env", "TRICKY"])
+    assert rc == 0
+    # Round-trip through bash.
+    result = subprocess.run(
+        ["bash", "-c", f'{out.strip()}; printf %s "$TRICKY"'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout == "it's \"quoted\" and 'risky'"
+
+
+def test_env_refuses_when_any_name_is_hidden():
+    store.set_secret(name="VIS", value="v", hidden=False, source="localhost", purpose="")
+    store.set_secret(name="HID", value="h", hidden=True, source="localhost", purpose="")
+    rc, _, err = _run(["env", "VIS", "HID"])
+    assert rc == 64
+    assert "HID" in err
+
+
+def test_env_missing_name_is_user_error():
+    rc, _, _ = _run(["env", "NOPE"])
+    assert rc == 64

--- a/tests/unit/test_cli_get.py
+++ b/tests/unit/test_cli_get.py
@@ -1,51 +1,36 @@
 from __future__ import annotations
 
-import io
-from contextlib import redirect_stderr, redirect_stdout
-
 import pytest
 
 from shushu import store
 from shushu.cli import main
 
 
-@pytest.fixture(autouse=True)
-def _tmp_home(monkeypatch, tmp_path):
-    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
-
-
-def _run(argv):
-    out, err = io.StringIO(), io.StringIO()
-    try:
-        with redirect_stdout(out), redirect_stderr(err):
-            rc = main(argv)
-    except SystemExit as exc:
-        rc = exc.code
-    return rc, out.getvalue(), err.getvalue()
-
-
-def test_get_visible_prints_value():
+def test_get_visible_prints_value(cli_run):
     store.set_secret(name="FOO", value="bar", hidden=False, source="localhost", purpose="")
-    rc, out, _ = _run(["get", "FOO"])
+    rc, out, _ = cli_run(["get", "FOO"])
     assert rc == 0
     assert out.strip() == "bar"
 
 
-def test_get_hidden_refuses_with_remediation():
+def test_get_hidden_refuses_with_remediation(cli_run):
     store.set_secret(name="SECRET", value="s", hidden=True, source="localhost", purpose="")
-    rc, _, err = _run(["get", "SECRET"])
+    rc, _, err = cli_run(["get", "SECRET"])
     assert rc == 64
     assert "hidden" in err.lower()
     assert "inject" in err.lower()
 
 
-def test_get_missing_is_user_error():
-    rc, _, err = _run(["get", "NOPE"])
+def test_get_missing_is_user_error(cli_run):
+    rc, _, err = cli_run(["get", "NOPE"])
     assert rc == 64
     assert "NOPE" in err
 
 
 def test_get_does_not_accept_user_flag():
-    # argparse rejects unknown flags with exit 2.
-    rc, _, _ = _run(["get", "FOO", "--user", "alice"])
-    assert rc == 2
+    # argparse rejects unknown flags by calling sys.exit(2) (raises SystemExit).
+    # Use pytest.raises so the expected exit code is asserted explicitly,
+    # rather than swallowed by the cli_run helper.
+    with pytest.raises(SystemExit) as exc_info:
+        main(["get", "FOO", "--user", "alice"])
+    assert exc_info.value.code == 2

--- a/tests/unit/test_cli_get.py
+++ b/tests/unit/test_cli_get.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+
+from shushu import store
+from shushu.cli import main
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = main(argv)
+    except SystemExit as exc:
+        rc = exc.code
+    return rc, out.getvalue(), err.getvalue()
+
+
+def test_get_visible_prints_value():
+    store.set_secret(name="FOO", value="bar", hidden=False, source="localhost", purpose="")
+    rc, out, _ = _run(["get", "FOO"])
+    assert rc == 0
+    assert out.strip() == "bar"
+
+
+def test_get_hidden_refuses_with_remediation():
+    store.set_secret(name="SECRET", value="s", hidden=True, source="localhost", purpose="")
+    rc, _, err = _run(["get", "SECRET"])
+    assert rc == 64
+    assert "hidden" in err.lower()
+    assert "inject" in err.lower()
+
+
+def test_get_missing_is_user_error():
+    rc, _, err = _run(["get", "NOPE"])
+    assert rc == 64
+    assert "NOPE" in err
+
+
+def test_get_does_not_accept_user_flag():
+    # argparse rejects unknown flags with exit 2.
+    rc, _, _ = _run(["get", "FOO", "--user", "alice"])
+    assert rc == 2

--- a/tests/unit/test_cli_list.py
+++ b/tests/unit/test_cli_list.py
@@ -1,44 +1,27 @@
 from __future__ import annotations
 
-import io
 import json
-from contextlib import redirect_stdout
-
-import pytest
 
 from shushu import store
-from shushu.cli import main
 
 
-@pytest.fixture(autouse=True)
-def _tmp_home(monkeypatch, tmp_path):
-    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
-
-
-def _run(argv):
-    buf = io.StringIO()
-    with redirect_stdout(buf):
-        rc = main(argv)
-    return rc, buf.getvalue()
-
-
-def test_list_empty_prints_nothing_text():
-    rc, out = _run(["list"])
+def test_list_empty_prints_nothing_text(cli_run):
+    rc, out, _ = cli_run(["list"])
     assert rc == 0
     assert out == ""
 
 
-def test_list_names_sorted_one_per_line():
+def test_list_names_sorted_one_per_line(cli_run):
     for n in ["C", "A", "B"]:
         store.set_secret(name=n, value="v", hidden=False, source="localhost", purpose="")
-    rc, out = _run(["list"])
+    rc, out, _ = cli_run(["list"])
     assert rc == 0
     assert out.splitlines() == ["A", "B", "C"]
 
 
-def test_list_json():
+def test_list_json(cli_run):
     store.set_secret(name="X", value="v", hidden=False, source="localhost", purpose="")
-    rc, out = _run(["list", "--json"])
+    rc, out, _ = cli_run(["list", "--json"])
     assert rc == 0
     payload = json.loads(out)
     assert payload == {"ok": True, "names": ["X"]}

--- a/tests/unit/test_cli_list.py
+++ b/tests/unit/test_cli_list.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+
+import pytest
+
+from shushu import store
+from shushu.cli import main
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
+
+
+def _run(argv):
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(argv)
+    return rc, buf.getvalue()
+
+
+def test_list_empty_prints_nothing_text():
+    rc, out = _run(["list"])
+    assert rc == 0
+    assert out == ""
+
+
+def test_list_names_sorted_one_per_line():
+    for n in ["C", "A", "B"]:
+        store.set_secret(name=n, value="v", hidden=False, source="localhost", purpose="")
+    rc, out = _run(["list"])
+    assert rc == 0
+    assert out.splitlines() == ["A", "B", "C"]
+
+
+def test_list_json():
+    store.set_secret(name="X", value="v", hidden=False, source="localhost", purpose="")
+    rc, out = _run(["list", "--json"])
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload == {"ok": True, "names": ["X"]}

--- a/tests/unit/test_cli_run.py
+++ b/tests/unit/test_cli_run.py
@@ -1,27 +1,10 @@
 from __future__ import annotations
 
-import io
 import os
 import subprocess  # noqa: S404
 import sys
-from contextlib import redirect_stderr, redirect_stdout
-
-import pytest
 
 from shushu import store
-from shushu.cli import main
-
-
-@pytest.fixture(autouse=True)
-def _tmp_home(monkeypatch, tmp_path):
-    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
-
-
-def _run(argv):
-    out, err = io.StringIO(), io.StringIO()
-    with redirect_stdout(out), redirect_stderr(err):
-        rc = main(argv)
-    return rc, out.getvalue(), err.getvalue()
 
 
 def test_run_parses_inject_spec_visible_secret():
@@ -73,19 +56,19 @@ def test_run_hidden_secret_injects_ok():
     assert out.stdout.strip() == "secret"
 
 
-def test_run_malformed_inject_is_user_error():
-    rc, _, err = _run(["run", "--inject", "=NAME", "--", "/bin/true"])
+def test_run_malformed_inject_is_user_error(cli_run):
+    rc, _, err = cli_run(["run", "--inject", "=NAME", "--", "/bin/true"])
     assert rc == 64
     assert "VAR=NAME" in err
 
 
-def test_run_missing_secret_is_user_error():
-    rc, _, _ = _run(["run", "--inject", "X=NOPE", "--", "/bin/true"])
+def test_run_missing_secret_is_user_error(cli_run):
+    rc, _, _ = cli_run(["run", "--inject", "X=NOPE", "--", "/bin/true"])
     assert rc == 64
 
 
-def test_run_requires_double_dash_before_cmd():
-    rc, _, _ = _run(["run", "--inject", "X=VIS"])  # no cmd
+def test_run_requires_double_dash_before_cmd(cli_run):
+    rc, _, _ = cli_run(["run", "--inject", "X=VIS"])  # no cmd
     assert rc == 64
 
 

--- a/tests/unit/test_cli_run.py
+++ b/tests/unit/test_cli_run.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import io
+import os
+import subprocess  # noqa: S404
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+
+from shushu import store
+from shushu.cli import main
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHUSHU_HOME", str(tmp_path / "shushu"))
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def test_run_parses_inject_spec_visible_secret():
+    store.set_secret(name="VIS", value="hello", hidden=False, source="localhost", purpose="")
+    # Use subprocess to actually exec (so os.execvp doesn't kill the test).
+    out = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "shushu",
+            "run",
+            "--inject",
+            "X=VIS",
+            "--",
+            sys.executable,
+            "-c",
+            "import os; print(os.environ['X'])",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "SHUSHU_HOME": os.environ["SHUSHU_HOME"]},
+    )
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "hello"
+
+
+def test_run_hidden_secret_injects_ok():
+    store.set_secret(name="HID", value="secret", hidden=True, source="localhost", purpose="")
+    out = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "shushu",
+            "run",
+            "--inject",
+            "Y=HID",
+            "--",
+            sys.executable,
+            "-c",
+            "import os; print(os.environ['Y'])",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "SHUSHU_HOME": os.environ["SHUSHU_HOME"]},
+    )
+    assert out.returncode == 0
+    assert out.stdout.strip() == "secret"
+
+
+def test_run_malformed_inject_is_user_error():
+    rc, _, err = _run(["run", "--inject", "=NAME", "--", "/bin/true"])
+    assert rc == 64
+    assert "VAR=NAME" in err
+
+
+def test_run_missing_secret_is_user_error():
+    rc, _, _ = _run(["run", "--inject", "X=NOPE", "--", "/bin/true"])
+    assert rc == 64
+
+
+def test_run_requires_double_dash_before_cmd():
+    rc, _, _ = _run(["run", "--inject", "X=VIS"])  # no cmd
+    assert rc == 64
+
+
+def test_run_duplicate_var_last_wins():
+    store.set_secret(name="A", value="one", hidden=False, source="localhost", purpose="")
+    store.set_secret(name="B", value="two", hidden=False, source="localhost", purpose="")
+    out = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "shushu",
+            "run",
+            "--inject",
+            "X=A",
+            "--inject",
+            "X=B",
+            "--",
+            sys.executable,
+            "-c",
+            "import os; print(os.environ['X'])",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "SHUSHU_HOME": os.environ["SHUSHU_HOME"]},
+    )
+    assert out.returncode == 0
+    assert out.stdout.strip() == "two"

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "shushu"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Five real handlers replace the last `NotImplementedError` stubs on the
self-mode surface. After this PR, every verb in `shushu --help` runs
end-to-end (admin mode + integration tests are Task 26 → PR #7).

| Task | Verb | Notes |
|---|---|---|
| 21 | `get` | Print value to stdout. Refuses if hidden (HiddenError → 64 with remediation). `--user` deliberately not registered — admin can never extract values via the CLI. |
| 22 | `env` | POSIX-quoted `export` lines for `eval $(shushu env A B)`. Refuses **the whole call** if any name is hidden (atomicity). Single-quote escaping round-trips through bash. |
| 23 | `run --inject` | `os.execvpe` the child with secrets stamped into env. Both visible and hidden allowed (only consumer for hidden). Explicit per-case malform errors. Last-wins on duplicate VAR. |
| 24 | `list` | Names only, sorted, one per line. `--json` payload. `--user` / `--all-users` raise `not yet implemented` (64) pending Task 26. |
| 25 | `delete` | Remove a secret. NotFoundError → 64. `--user` deferred to Task 26. |

### Contracts enforced

- **H2 hidden contract** holds end-to-end:
  - `get` / `env` refuse hidden secrets.
  - `run --inject` is the only consumer that accepts them.
  - `set --hidden` is immutable post-create (verified back in PR #5).
- **Atomicity for `env`**: refuses the whole call if any name is
  hidden, never a partial print before the error.
- **Explicit malform errors for `run --inject`**: one error per case
  (missing `=`, empty VAR, empty NAME) with form hint
  `expected form: VAR=NAME`.
- **Exit-code consistency**: "not yet implemented" is `EXIT_USER_ERROR`
  (64) across the board, not `EXIT_PRIVILEGE` (66). The plan snippets
  hard-coded `66`; substituted per the convention from PR #4 cleanup.

### Tooling improvements (commit `c3bf288`)

- Reverted a brief `.flake8` per-file-ignores drift (test_cli_env.py
  added `S404,S603,S607` blanket; restored to `tests/*:S101` only and
  used per-line `# noqa` instead).
- Extended `.claude/skills/run-tests/scripts/test.sh` with
  `--clean-smoke <name>` and `--smoke-home <name>` so smoke flows never
  need a manual `rm -rf` against `/tmp/shushu-tests/*`. Both validate
  NAME (rejects `..`, `/`, empty, etc.) before touching disk.

Version bump: `0.5.0` → `0.6.0`.

## Test plan

- [x] `bash .claude/skills/run-tests/scripts/test.sh -p` — 114 passing (95 prior + 19 new)
- [x] `uv run flake8 src/shushu tests` — clean
- [x] `uv run black --check src/shushu tests` — clean
- [x] `uv run isort --check-only src/shushu tests` — clean
- [x] `uv run bandit -r src/shushu -c pyproject.toml` — clean
- [x] `uv run pylint --errors-only src/shushu` — clean
- [x] `scripts/lint-md.sh` — 0 errors
- [x] `uv run shushu --version` → `shushu 0.6.0`
- [x] Manual smoke for each verb (text + JSON, hidden, malform, missing) — see commit messages
- [ ] CI green on PR head

## Out of scope

- Admin mode (`--user` / `--all-users`) for `set` / `show` / `generate` / `list` / `delete` / `overview` / `doctor` — Task 26
- Integration tests / Docker — Task 26
- 13-step `tests/test_self_verify.py` lifecycle gate — Task 27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude