### PR TITLE
Admin mode + integration tests (Task 26)

### DIFF
--- a/.claude/skills/pr-review/scripts/pr-status.sh
+++ b/.claude/skills/pr-review/scripts/pr-status.sh
@@ -141,6 +141,15 @@ if [[ "$SONAR_OPEN" != "0" ]]; then
         | jq -r '.issues[] | "    • [\(.rule)] \(.component | sub("^[^:]+:"; ""))(:\(.line // "?")) (\(.severity)) — \(.message)"'
 fi
 
+# When the QG itself failed, surface the failing conditions (often coverage /
+# duplication thresholds — failures with zero OPEN issues otherwise look opaque).
+if [[ "$SONAR_QG_STATUS" == "ERROR" || "$SONAR_QG_STATUS" == "WARN" ]]; then
+    echo
+    echo "  SonarCloud failed conditions:"
+    echo "$SONAR_QG" \
+        | jq -r '.projectStatus.conditions[] | select(.status != "OK") | "    • \(.metricKey) (\(.comparator) \(.errorThreshold)): actual = \(.actualValue)"'
+fi
+
 # ── 5. Tally + summary ────────────────────────────────────────────────────
 echo
 echo "── Inline threads ────────────────────────────────────────────────────"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,12 +32,14 @@ jobs:
       - run: uv sync
       - run: uv run pytest -n auto --cov=shushu --cov-report=term -m "not integration"
 
-  # Integration job re-introduced in Task 26 once tests/integration/ exists
-  # (admin setuid-fork handoff tests need real useradd/userdel and run inside
-  # the disposable Docker image at .github/workflows/Dockerfile.integration).
-  # Earlier attempt used `if: hashFiles(...) != ''` to gate it, which GitHub
-  # rejected at workflow-validation time and prevented the entire `tests`
-  # workflow from starting (visible as a 0s "workflow file issue" failure).
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Build integration image
+        run: docker build -f .github/workflows/Dockerfile.integration -t shushu-int .
+      - name: Run integration tests
+        run: docker run --rm -e SHUSHU_DOCKER=1 shushu-int uv run pytest tests/integration -v
 
   version-check:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,23 @@ with merged PRs per the per-PR version bump discipline documented in
 
 ## [Unreleased]
 
-- (nothing yet — v0.6.0 cut; next bump on the following PR)
+- (nothing yet — v0.7.0 cut; next bump on the following PR)
+
+## [0.7.0] — 2026-04-25
+
+### Added
+
+- **Admin mode** — `--user NAME` and (where applicable) `--all-users` flags now actually work for `set`, `generate`, `show`, `delete`, `list`, `overview`, and `doctor`. Implementation routes through a new `src/shushu/admin.py` module on top of `privilege.run_as_user`:
+  - **Write-side `--user`** (`set`, `generate`, `delete`): root forks → drops to target uid/gid → writes the record. Resulting files are mode 0600 and owned by the target user, never by root. `source` defaults to `admin:<invoker>` (preserved from `$SUDO_USER`); `handed_over_by = sudo_invoker()` is stamped on create and **preserved on overwrite** (history is never erased). An explicit `--source` from the caller is honored.
+  - **Read-side `--user`** (`show`, `list`, `overview`, `doctor`): also fork-and-drop, so the read happens under the target uid (consistent with self-mode permissions).
+  - **`--all-users`** (`list`, `overview`, `doctor`): root reads each user's `secrets.json` directly via `admin.store_paths_for(info)` — no fork, no identity drop. Skips users with no home dir or no store. `admin.for_each_user(fn)` enforces the root requirement up front.
+  - **H2 contract preserved**: `get`, `env`, and `run` deliberately do NOT register admin flags. Admin can never extract a value through the CLI; for plaintext, use `sudo cat`.
+- **Integration test suite** — new `tests/integration/` directory with two modules (`test_admin_handoff.py`, `test_all_users_enumeration.py`) that exercise real `useradd` / `userdel` and the setuid-fork. 11 tests covering: file ownership/mode after handoff, hidden-value non-disclosure across all admin paths, `--all-users` enumeration, `test_no_root_owned_files_left_behind` safety net. Both modules apply `pytest.mark.integration` + `skipif(euid != 0 and not SHUSHU_DOCKER)`. The CI `integration` job is back, running them inside `.github/workflows/Dockerfile.integration` per run with `SHUSHU_DOCKER=1`.
+
+### Fixed
+
+- `privilege.run_as_user` now flushes stdout/stderr before every `os._exit` call. The success path was already doing this; added the same flush before `os._exit(66)` (PrivilegeError path) and `os._exit(70)` (generic exception path) so closures that print-then-raise don't lose buffered output. Caught while writing the integration suite — `subprocess.run(capture_output=True)` was getting empty stdout from the child without the flushes.
+- `admin.as_user` sets `HOME` to the target user's home dir inside the child fork (after the uid drop, before invoking the closure). Without this, `Path.home()` in the child resolved to root's HOME (inherited from the parent's environment) and `ensure_store_dir` raised `PermissionError`. Caught by integration tests on first run.
 
 ## [0.6.0] — 2026-04-25
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shushu"
-version = "0.6.0"
+version = "0.7.0"
 description = "shushu CLI"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/shushu/admin.py
+++ b/src/shushu/admin.py
@@ -14,7 +14,15 @@ from shushu.cli._errors import EXIT_BACKEND, ShushuError
 
 
 def as_user(name: str, fn: Callable[[], int]) -> int:
-    """Run fn() as the target user via fork + setuid. Returns the child's exit code."""
+    """Run fn() as the target user via fork + setuid. Returns the child's exit code.
+
+    Sets HOME to the target user's home directory in the child environment
+    so that Path.home() resolves correctly after the uid switch. Each fn
+    closure is still responsible for popping SHUSHU_HOME before calling
+    store.* functions.
+    """
+    import os as _os
+
     privilege.require_root(f"--user {name}")
     try:
         info = users.resolve(name)
@@ -30,7 +38,12 @@ def as_user(name: str, fn: Callable[[], int]) -> int:
             f"user {name!r} has no home directory",
             "create one or pick a different user",
         )
-    return privilege.run_as_user(info, fn)
+
+    def _wrapped() -> int:
+        _os.environ["HOME"] = str(info.home)
+        return fn()
+
+    return privilege.run_as_user(info, _wrapped)
 
 
 def for_each_user(

--- a/src/shushu/admin.py
+++ b/src/shushu/admin.py
@@ -1,0 +1,66 @@
+"""Admin-mode helpers: fork-as-target-user for writes, read-as-root for reads.
+
+Used by every CLI command that accepts --user / --all-users. Keeps the
+identity-switch logic out of individual command handlers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from shushu import privilege, users
+from shushu.cli._errors import EXIT_BACKEND, ShushuError
+
+
+def as_user(name: str, fn: Callable[[], int]) -> int:
+    """Run fn() as the target user via fork + setuid. Returns the child's exit code."""
+    privilege.require_root(f"--user {name}")
+    try:
+        info = users.resolve(name)
+    except KeyError as exc:
+        raise ShushuError(
+            EXIT_BACKEND,
+            f"no OS user {name!r} on this host",
+            "check: getent passwd",
+        ) from exc
+    if not info.home.exists():
+        raise ShushuError(
+            EXIT_BACKEND,
+            f"user {name!r} has no home directory",
+            "create one or pick a different user",
+        )
+    return privilege.run_as_user(info, fn)
+
+
+def for_each_user(
+    fn: Callable[[users.UserInfo], dict[str, Any] | None],
+) -> list[dict[str, Any]]:
+    """Enumerate all OS users with a shushu store and invoke fn per-user.
+
+    Reads only — no uid switch (root reads files directly). Skips users
+    with no home dir or no secrets.json. The caller must be root.
+    """
+    privilege.require_root("--all-users")
+    out: list[dict[str, Any]] = []
+    for info in users.all_users():
+        if not info.home.exists():
+            continue
+        if not (info.home / ".local/share/shushu/secrets.json").exists():
+            continue
+        row = fn(info)
+        if row is not None:
+            out.append(row)
+    return out
+
+
+def store_paths_for(info: users.UserInfo):
+    """Compute fs.StorePaths as if we were `info` (without forking).
+
+    Used by --all-users readers so root can stat/read each user's
+    secrets.json directly.
+    """
+    from shushu import fs  # local to avoid circular
+
+    base = info.home / ".local/share/shushu"
+    return fs.StorePaths(dir=base, file=base / "secrets.json", lock=base / ".lock")

--- a/src/shushu/admin.py
+++ b/src/shushu/admin.py
@@ -13,15 +13,23 @@ from shushu import privilege, users
 from shushu.cli._errors import EXIT_BACKEND, ShushuError
 
 
-def as_user(name: str, fn: Callable[[], int]) -> int:
+def as_user(name: str, fn: Callable[[], int], *, json_mode: bool = False) -> int:
     """Run fn() as the target user via fork + setuid. Returns the child's exit code.
 
     Sets HOME to the target user's home directory in the child environment
     so that Path.home() resolves correctly after the uid switch. Each fn
     closure is still responsible for popping SHUSHU_HOME before calling
     store.* functions.
+
+    Translates ShushuError and store.* exceptions raised inside fn() to
+    proper exit codes via cli._translate.translate_errors, so common
+    failures (invalid date, missing record, hidden value request) produce
+    the same structured output as self-mode instead of being caught by
+    privilege.run_as_user's generic Exception handler as EXIT_INTERNAL.
     """
     import os as _os
+
+    from shushu.cli._translate import translate_errors
 
     privilege.require_root(f"--user {name}")
     try:
@@ -41,7 +49,7 @@ def as_user(name: str, fn: Callable[[], int]) -> int:
 
     def _wrapped() -> int:
         _os.environ["HOME"] = str(info.home)
-        return fn()
+        return translate_errors(fn, json_mode=json_mode)
 
     return privilege.run_as_user(info, _wrapped)
 
@@ -59,7 +67,7 @@ def for_each_user(
     for info in users.all_users():
         if not info.home.exists():
             continue
-        if not (info.home / ".local/share/shushu/secrets.json").exists():
+        if not store_paths_for(info).file.exists():
             continue
         row = fn(info)
         if row is not None:

--- a/src/shushu/cli/_commands/_write_helper.py
+++ b/src/shushu/cli/_commands/_write_helper.py
@@ -10,13 +10,24 @@ from shushu import store
 from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 
 
-def write_value(args, value: str, alert_at):
+def write_value(
+    args,
+    value: str,
+    alert_at,
+    *,
+    default_source: str = "localhost",
+    default_handed_over_by: str | None = None,
+):
     """Create-or-overwrite a record with `value`.
 
     On overwrite: preserve `source`, `hidden`, and `handed_over_by` from the
-    existing record; reject any explicit attempt to change them. On create:
-    `source` defaults to `"localhost"`, `hidden` defaults to `args.hidden`,
-    `handed_over_by` is None.
+    existing record; reject any explicit attempt to change them.
+
+    On create: `source` defaults to `args.source or default_source`,
+    `hidden` defaults to `args.hidden`, `handed_over_by = default_handed_over_by`.
+    The two `default_*` kwargs are how the admin path injects
+    `default_source = f"admin:{invoker}"` and `default_handed_over_by = invoker`
+    without duplicating the create/overwrite logic.
 
     Mutable metadata fields (`purpose`, `rotation_howto`, `alert_at`) follow
     the "user-supplied wins; otherwise inherit from existing" rule.
@@ -52,9 +63,9 @@ def write_value(args, value: str, alert_at):
         name=args.name,
         value=value,
         hidden=args.hidden,
-        source=args.source or "localhost",
+        source=args.source or default_source,
         purpose=args.purpose or "",
         rotation_howto=args.rotate_howto or "",
         alert_at=alert_at,
-        handed_over_by=None,
+        handed_over_by=default_handed_over_by,
     )

--- a/src/shushu/cli/_commands/delete.py
+++ b/src/shushu/cli/_commands/delete.py
@@ -34,4 +34,4 @@ def _handle_admin_user(args) -> int:
             print(f"shushu: deleted {name_to_delete}")
         return 0
 
-    return admin.as_user(args.user, _child)
+    return admin.as_user(args.user, _child, json_mode=args.json)

--- a/src/shushu/cli/_commands/delete.py
+++ b/src/shushu/cli/_commands/delete.py
@@ -3,20 +3,35 @@
 from __future__ import annotations
 
 from shushu import store
-from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
     if getattr(args, "user", None):
-        raise ShushuError(
-            EXIT_USER_ERROR,
-            "delete --user not yet implemented",
-            "coming in Task 26",
-        )
+        return _handle_admin_user(args)
     store.delete(args.name)  # NotFoundError caught by main()
     if args.json:
         emit_result({"name": args.name, "deleted": True}, json_mode=True)
     else:
         print(f"shushu: deleted {args.name}")
     return 0
+
+
+def _handle_admin_user(args) -> int:
+    import os as _os
+
+    from shushu import admin
+
+    name_to_delete = args.name
+    json_mode = args.json
+
+    def _child() -> int:
+        _os.environ.pop("SHUSHU_HOME", None)
+        store.delete(name_to_delete)
+        if json_mode:
+            emit_result({"name": name_to_delete, "deleted": True}, json_mode=True)
+        else:
+            print(f"shushu: deleted {name_to_delete}")
+        return 0
+
+    return admin.as_user(args.user, _child)

--- a/src/shushu/cli/_commands/doctor.py
+++ b/src/shushu/cli/_commands/doctor.py
@@ -72,7 +72,7 @@ def _handle_admin_user(args) -> int:
             print(f"pass={s['pass']} warn={s['warn']} fail={s['fail']}")
         return 0 if payload["summary"]["fail"] == 0 else EXIT_STATE
 
-    return admin.as_user(args.user, _child)
+    return admin.as_user(args.user, _child, json_mode=args.json)
 
 
 def _run_self_checks():
@@ -115,9 +115,12 @@ def _check_store_dir(paths):
 def _check_secrets_file_at(paths):
     """Return (data, checks, fatal). `fatal=True` means stop further checks.
 
-    Reads `paths.file` directly so root can inspect any user's store without
-    forking. Uses `store.load()` for self-mode (correct lock path), and
-    direct JSON parsing for foreign-user paths (root reads files directly).
+    Reads and parses `paths.file` directly for any provided `StorePaths`.
+    This does NOT call `store.load()` and does NOT take a lock — it
+    performs direct JSON validation/parsing so root can inspect any user's
+    store without forking, and so the same logic works for self-mode and
+    foreign-user paths uniformly. The corresponding `_check_record` helper
+    runs against the parsed `StoreData`.
     """
     import json as _json
 
@@ -185,11 +188,11 @@ def _parse_store_data(raw: dict) -> store.StoreData:
     """Parse a JSON dict into StoreData without going through store.load().
 
     Lets root read any user's secrets.json directly (no fork, no lock) for
-    the --all-users doctor path.
+    the --all-users doctor path. Uses the public `store.record_from_json`
+    helper so the per-record schema validation stays consistent with
+    `store.load()`.
     """
-    from shushu.store import _json_to_record  # type: ignore[attr-defined]
-
-    secrets = [_json_to_record(d) for d in raw.get("secrets", [])]
+    secrets = [store.record_from_json(d) for d in raw.get("secrets", [])]
     return store.StoreData(schema_version=store.SCHEMA_VERSION, secrets=secrets)
 
 

--- a/src/shushu/cli/_commands/doctor.py
+++ b/src/shushu/cli/_commands/doctor.py
@@ -5,19 +5,16 @@ from __future__ import annotations
 import stat as stat_
 
 from shushu import alerts, fs, store
-from shushu.cli._errors import EXIT_STATE, EXIT_USER_ERROR, ShushuError
+from shushu.cli._errors import EXIT_STATE
 from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
     json_mode = args.json
-    # Admin variants (--user / --all-users) are wired in Task 26.
-    if getattr(args, "user", None) or getattr(args, "all_users", False):
-        raise ShushuError(
-            EXIT_USER_ERROR,
-            "doctor --user / --all-users not yet implemented",
-            "coming in Task 26",
-        )
+    if getattr(args, "all_users", False):
+        return _handle_all_users(args)
+    if getattr(args, "user", None):
+        return _handle_admin_user(args)
     report = _run_self_checks()
     payload = {"checks": report, "summary": _summarize(report)}
     if json_mode:
@@ -30,10 +27,65 @@ def handle(args) -> int:
     return 0 if payload["summary"]["fail"] == 0 else EXIT_STATE
 
 
+def _handle_all_users(args) -> int:
+    from shushu import admin
+
+    json_mode = args.json
+
+    def _row(info):
+        paths = admin.store_paths_for(info)
+        report = _run_checks_for_paths(paths)
+        summary = _summarize(report)
+        return {"user": info.name, "checks": report, "summary": summary}
+
+    rows = admin.for_each_user(_row)
+    if json_mode:
+        emit_result({"users": rows}, json_mode=True)
+    else:
+        any_fail = False
+        for row in rows:
+            print(f"# {row['user']}")
+            for c in row["checks"]:
+                print(f"  [{c['status']}] {c['name']}: {c['detail']}")
+            s = row["summary"]
+            print(f"  pass={s['pass']} warn={s['warn']} fail={s['fail']}")
+            if s["fail"] > 0:
+                any_fail = True
+    return 0 if not any_fail else EXIT_STATE
+
+
+def _handle_admin_user(args) -> int:
+    import os as _os
+
+    from shushu import admin
+
+    json_mode = args.json
+
+    def _child() -> int:
+        _os.environ.pop("SHUSHU_HOME", None)
+        report = _run_self_checks()
+        payload = {"checks": report, "summary": _summarize(report)}
+        if json_mode:
+            emit_result(payload, json_mode=True)
+        else:
+            for c in report:
+                print(f"[{c['status']}] {c['name']}: {c['detail']}")
+            s = payload["summary"]
+            print(f"pass={s['pass']} warn={s['warn']} fail={s['fail']}")
+        return 0 if payload["summary"]["fail"] == 0 else EXIT_STATE
+
+    return admin.as_user(args.user, _child)
+
+
 def _run_self_checks():
     paths = fs.user_store_paths()
+    return _run_checks_for_paths(paths)
+
+
+def _run_checks_for_paths(paths):
+    """Run all store checks against the given StorePaths. Root-readable."""
     checks = [_check_store_dir(paths)]
-    data, file_checks, fatal = _check_secrets_file(paths)
+    data, file_checks, fatal = _check_secrets_file_at(paths)
     checks.extend(file_checks)
     if fatal:
         return checks
@@ -62,8 +114,15 @@ def _check_store_dir(paths):
     return {"name": "store_dir", "status": "PASS", "detail": str(paths.dir)}
 
 
-def _check_secrets_file(paths):
-    """Return (data, checks, fatal). `fatal=True` means stop further checks."""
+def _check_secrets_file_at(paths):
+    """Return (data, checks, fatal). `fatal=True` means stop further checks.
+
+    Reads `paths.file` directly so root can inspect any user's store without
+    forking. Uses `store.load()` for self-mode (correct lock path), and
+    direct JSON parsing for foreign-user paths (root reads files directly).
+    """
+    import json as _json
+
     if not paths.file.exists():
         empty = store.StoreData(schema_version=store.SCHEMA_VERSION, secrets=[])
         return empty, [{"name": "schema_version", "status": "PASS", "detail": "empty store"}], False
@@ -92,8 +151,23 @@ def _check_secrets_file(paths):
             }
         )
     try:
-        data = store.load()
-    except store.StateError as exc:
+        raw = _json.loads(paths.file.read_text(encoding="utf-8"))
+        sv = raw.get("schema_version")
+        if not isinstance(sv, int):
+            raise store.StateError(
+                f"secrets.json is missing or has non-integer schema_version (got {sv!r})"
+            )
+        if sv != store.SCHEMA_VERSION:
+            raise store.StateError(
+                f"store schema_version={sv} but this binary supports {store.SCHEMA_VERSION}"
+            )
+        secrets_raw = raw.get("secrets", [])
+        if not isinstance(secrets_raw, list):
+            raise store.StateError(
+                f"secrets.json 'secrets' field must be a list (got {type(secrets_raw).__name__})"
+            )
+        data = _parse_store_data(raw)
+    except (store.StateError, ValueError, KeyError, TypeError) as exc:
         checks.append({"name": "schema_version", "status": "FAIL", "detail": str(exc)})
         return None, checks, True
     except OSError as exc:
@@ -107,6 +181,18 @@ def _check_secrets_file(paths):
         return None, checks, True
     checks.append({"name": "schema_version", "status": "PASS", "detail": f"v{data.schema_version}"})
     return data, checks, False
+
+
+def _parse_store_data(raw: dict) -> store.StoreData:
+    """Parse a JSON dict into StoreData without going through store.load().
+
+    Lets root read any user's secrets.json directly (no fork, no lock) for
+    the --all-users doctor path.
+    """
+    from shushu.store import _json_to_record  # type: ignore[attr-defined]
+
+    secrets = [_json_to_record(d) for d in raw.get("secrets", [])]
+    return store.StoreData(schema_version=store.SCHEMA_VERSION, secrets=secrets)
 
 
 def _check_record(record):

--- a/src/shushu/cli/_commands/doctor.py
+++ b/src/shushu/cli/_commands/doctor.py
@@ -39,18 +39,16 @@ def _handle_all_users(args) -> int:
         return {"user": info.name, "checks": report, "summary": summary}
 
     rows = admin.for_each_user(_row)
+    any_fail = any(row["summary"]["fail"] > 0 for row in rows)
     if json_mode:
         emit_result({"users": rows}, json_mode=True)
     else:
-        any_fail = False
         for row in rows:
             print(f"# {row['user']}")
             for c in row["checks"]:
                 print(f"  [{c['status']}] {c['name']}: {c['detail']}")
             s = row["summary"]
             print(f"  pass={s['pass']} warn={s['warn']} fail={s['fail']}")
-            if s["fail"] > 0:
-                any_fail = True
     return 0 if not any_fail else EXIT_STATE
 
 

--- a/src/shushu/cli/_commands/generate.py
+++ b/src/shushu/cli/_commands/generate.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 from shushu import alerts
 from shushu import generate as gen
-from shushu import privilege
+from shushu import privilege, store
 from shushu.cli._commands._write_helper import write_value
 from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
-    _check_admin(args)
+    if args.user is not None:
+        return _handle_admin_user(args)
     _check_admin_source_prefix(args.source)
     alert_at = _parse_alert_at(args)
     value = _random_value(args)
@@ -20,15 +21,88 @@ def handle(args) -> int:
     return 0
 
 
-def _check_admin(args) -> None:
-    if args.user is None:
-        return
-    privilege.require_root(f"generate --user {args.user} {args.name}")
-    raise ShushuError(
-        EXIT_USER_ERROR,
-        "generate --user not yet implemented",
-        "coming in Task 26",
-    )
+def _handle_admin_user(args) -> int:
+    import os as _os
+
+    from shushu import admin
+
+    handed_over_by = privilege.sudo_invoker()
+    source = args.source or f"admin:{handed_over_by}"
+    arg_name = args.name
+    arg_nbytes = args.nbytes
+    arg_encoding = args.encoding
+    arg_purpose = args.purpose
+    arg_rotate_howto = args.rotate_howto
+    arg_alert_at = args.alert_at
+    arg_hidden = args.hidden
+    json_mode = args.json
+
+    def _child() -> int:
+        _os.environ.pop("SHUSHU_HOME", None)
+        try:
+            alert_at_c = alerts.parse_date(arg_alert_at)
+        except ValueError as exc:
+            raise ShushuError(
+                EXIT_USER_ERROR,
+                f"invalid date: {arg_alert_at!r}",
+                "use YYYY-MM-DD",
+            ) from exc
+        try:
+            value = gen.random_secret(nbytes=arg_nbytes, encoding=arg_encoding)
+        except ValueError as exc:
+            raise ShushuError(
+                EXIT_USER_ERROR,
+                str(exc),
+                "use positive --bytes and --encoding hex|base64",
+            ) from exc
+        try:
+            existing = store.get_record(arg_name)
+        except store.NotFoundError:
+            existing = None
+        if existing is not None:
+            rec = store.set_secret(
+                name=arg_name,
+                value=value,
+                hidden=existing.hidden,
+                source=existing.source,
+                purpose=arg_purpose or existing.purpose,
+                rotation_howto=arg_rotate_howto or existing.rotation_howto,
+                alert_at=alert_at_c if alert_at_c is not None else existing.alert_at,
+                handed_over_by=existing.handed_over_by,
+            )
+        else:
+            rec = store.set_secret(
+                name=arg_name,
+                value=value,
+                hidden=arg_hidden,
+                source=source,
+                purpose=arg_purpose or "",
+                rotation_howto=arg_rotate_howto or "",
+                alert_at=alert_at_c,
+                handed_over_by=handed_over_by,
+            )
+        # Emit using same logic as self-mode but suppress value for hidden.
+        if json_mode:
+            payload = {
+                "name": rec.name,
+                "hidden": rec.hidden,
+                "encoding": arg_encoding,
+                "bytes": arg_nbytes,
+            }
+            if not rec.hidden:
+                payload["value"] = rec.value
+            emit_result(payload, json_mode=True)
+        else:
+            if rec.hidden:
+                print(
+                    f"shushu: generated {rec.name} (hidden, {arg_nbytes} bytes {arg_encoding})"
+                )
+            else:
+                print(f"shushu: generated {rec.name} ({arg_nbytes} bytes {arg_encoding})")
+                print(rec.value)
+        return 0
+
+    return admin.as_user(args.user, _child)
 
 
 def _check_admin_source_prefix(source) -> None:

--- a/src/shushu/cli/_commands/generate.py
+++ b/src/shushu/cli/_commands/generate.py
@@ -2,12 +2,30 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from shushu import alerts
 from shushu import generate as gen
 from shushu import privilege, store
 from shushu.cli._commands._write_helper import write_value
 from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 from shushu.cli._output import emit_result
+
+
+@dataclass(frozen=True)
+class _AdminGenerateSnapshot:
+    """Plain-value snapshot of args for the admin fork-child closure."""
+
+    name: str
+    nbytes: int
+    encoding: str
+    purpose: str | None
+    rotate_howto: str | None
+    alert_at: str | None
+    hidden: bool
+    json_mode: bool
+    source: str
+    handed_over_by: str
 
 
 def handle(args) -> int:
@@ -27,80 +45,97 @@ def _handle_admin_user(args) -> int:
     from shushu import admin
 
     handed_over_by = privilege.sudo_invoker()
-    source = args.source or f"admin:{handed_over_by}"
-    arg_name = args.name
-    arg_nbytes = args.nbytes
-    arg_encoding = args.encoding
-    arg_purpose = args.purpose
-    arg_rotate_howto = args.rotate_howto
-    arg_alert_at = args.alert_at
-    arg_hidden = args.hidden
-    json_mode = args.json
+    snap = _AdminGenerateSnapshot(
+        name=args.name,
+        nbytes=args.nbytes,
+        encoding=args.encoding,
+        purpose=args.purpose,
+        rotate_howto=args.rotate_howto,
+        alert_at=args.alert_at,
+        hidden=args.hidden,
+        json_mode=args.json,
+        source=args.source or f"admin:{handed_over_by}",
+        handed_over_by=handed_over_by,
+    )
 
     def _child() -> int:
         _os.environ.pop("SHUSHU_HOME", None)
-        try:
-            alert_at_c = alerts.parse_date(arg_alert_at)
-        except ValueError as exc:
-            raise ShushuError(
-                EXIT_USER_ERROR,
-                f"invalid date: {arg_alert_at!r}",
-                "use YYYY-MM-DD",
-            ) from exc
-        try:
-            value = gen.random_secret(nbytes=arg_nbytes, encoding=arg_encoding)
-        except ValueError as exc:
-            raise ShushuError(
-                EXIT_USER_ERROR,
-                str(exc),
-                "use positive --bytes and --encoding hex|base64",
-            ) from exc
-        try:
-            existing = store.get_record(arg_name)
-        except store.NotFoundError:
-            existing = None
-        if existing is not None:
-            rec = store.set_secret(
-                name=arg_name,
-                value=value,
-                hidden=existing.hidden,
-                source=existing.source,
-                purpose=arg_purpose or existing.purpose,
-                rotation_howto=arg_rotate_howto or existing.rotation_howto,
-                alert_at=alert_at_c if alert_at_c is not None else existing.alert_at,
-                handed_over_by=existing.handed_over_by,
-            )
-        else:
-            rec = store.set_secret(
-                name=arg_name,
-                value=value,
-                hidden=arg_hidden,
-                source=source,
-                purpose=arg_purpose or "",
-                rotation_howto=arg_rotate_howto or "",
-                alert_at=alert_at_c,
-                handed_over_by=handed_over_by,
-            )
-        # Emit using same logic as self-mode but suppress value for hidden.
-        if json_mode:
-            payload = {
-                "name": rec.name,
-                "hidden": rec.hidden,
-                "encoding": arg_encoding,
-                "bytes": arg_nbytes,
-            }
-            if not rec.hidden:
-                payload["value"] = rec.value
-            emit_result(payload, json_mode=True)
-        else:
-            if rec.hidden:
-                print(f"shushu: generated {rec.name} (hidden, {arg_nbytes} bytes {arg_encoding})")
-            else:
-                print(f"shushu: generated {rec.name} ({arg_nbytes} bytes {arg_encoding})")
-                print(rec.value)
+        alert_at_c = _parse_alert_at_raw(snap.alert_at)
+        value = _random_value_raw(snap.nbytes, snap.encoding)
+        rec = _admin_create_or_overwrite(snap, value, alert_at_c)
+        _emit_admin(rec, snap)
         return 0
 
-    return admin.as_user(args.user, _child)
+    return admin.as_user(args.user, _child, json_mode=args.json)
+
+
+def _parse_alert_at_raw(raw):
+    try:
+        return alerts.parse_date(raw)
+    except ValueError as exc:
+        raise ShushuError(EXIT_USER_ERROR, f"invalid date: {raw!r}", "use YYYY-MM-DD") from exc
+
+
+def _random_value_raw(nbytes, encoding):
+    try:
+        return gen.random_secret(nbytes=nbytes, encoding=encoding)
+    except ValueError as exc:
+        raise ShushuError(
+            EXIT_USER_ERROR, str(exc), "use positive --bytes and --encoding hex|base64"
+        ) from exc
+
+
+def _admin_create_or_overwrite(snap, value, alert_at_c):
+    """Create or regenerate under target uid (admin path).
+
+    Mirrors set's overwrite-immutability semantics: preserve hidden /
+    source / handed_over_by from the existing record on overwrite.
+    """
+    try:
+        existing = store.get_record(snap.name)
+    except store.NotFoundError:
+        existing = None
+    if existing is not None:
+        return store.set_secret(
+            name=snap.name,
+            value=value,
+            hidden=existing.hidden,
+            source=existing.source,
+            purpose=snap.purpose or existing.purpose,
+            rotation_howto=snap.rotate_howto or existing.rotation_howto,
+            alert_at=alert_at_c if alert_at_c is not None else existing.alert_at,
+            handed_over_by=existing.handed_over_by,
+        )
+    return store.set_secret(
+        name=snap.name,
+        value=value,
+        hidden=snap.hidden,
+        source=snap.source,
+        purpose=snap.purpose or "",
+        rotation_howto=snap.rotate_howto or "",
+        alert_at=alert_at_c,
+        handed_over_by=snap.handed_over_by,
+    )
+
+
+def _emit_admin(rec, snap):
+    """Admin-path emit: hidden suppresses value in both JSON and text."""
+    if snap.json_mode:
+        payload = {
+            "name": rec.name,
+            "hidden": rec.hidden,
+            "encoding": snap.encoding,
+            "bytes": snap.nbytes,
+        }
+        if not rec.hidden:
+            payload["value"] = rec.value
+        emit_result(payload, json_mode=True)
+        return
+    if rec.hidden:
+        print(f"shushu: generated {rec.name} (hidden, {snap.nbytes} bytes {snap.encoding})")
+    else:
+        print(f"shushu: generated {rec.name} ({snap.nbytes} bytes {snap.encoding})")
+        print(rec.value)
 
 
 def _check_admin_source_prefix(source) -> None:

--- a/src/shushu/cli/_commands/generate.py
+++ b/src/shushu/cli/_commands/generate.py
@@ -94,9 +94,7 @@ def _handle_admin_user(args) -> int:
             emit_result(payload, json_mode=True)
         else:
             if rec.hidden:
-                print(
-                    f"shushu: generated {rec.name} (hidden, {arg_nbytes} bytes {arg_encoding})"
-                )
+                print(f"shushu: generated {rec.name} (hidden, {arg_nbytes} bytes {arg_encoding})")
             else:
                 print(f"shushu: generated {rec.name} ({arg_nbytes} bytes {arg_encoding})")
                 print(rec.value)

--- a/src/shushu/cli/_commands/generate.py
+++ b/src/shushu/cli/_commands/generate.py
@@ -2,30 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from shushu import alerts
 from shushu import generate as gen
-from shushu import privilege, store
+from shushu import privilege
 from shushu.cli._commands._write_helper import write_value
 from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 from shushu.cli._output import emit_result
-
-
-@dataclass(frozen=True)
-class _AdminGenerateSnapshot:
-    """Plain-value snapshot of args for the admin fork-child closure."""
-
-    name: str
-    nbytes: int
-    encoding: str
-    purpose: str | None
-    rotate_howto: str | None
-    alert_at: str | None
-    hidden: bool
-    json_mode: bool
-    source: str
-    handed_over_by: str
 
 
 def handle(args) -> int:
@@ -45,97 +27,23 @@ def _handle_admin_user(args) -> int:
     from shushu import admin
 
     handed_over_by = privilege.sudo_invoker()
-    snap = _AdminGenerateSnapshot(
-        name=args.name,
-        nbytes=args.nbytes,
-        encoding=args.encoding,
-        purpose=args.purpose,
-        rotate_howto=args.rotate_howto,
-        alert_at=args.alert_at,
-        hidden=args.hidden,
-        json_mode=args.json,
-        source=args.source or f"admin:{handed_over_by}",
-        handed_over_by=handed_over_by,
-    )
+    admin_source = args.source or f"admin:{handed_over_by}"
 
     def _child() -> int:
         _os.environ.pop("SHUSHU_HOME", None)
-        alert_at_c = _parse_alert_at_raw(snap.alert_at)
-        value = _random_value_raw(snap.nbytes, snap.encoding)
-        rec = _admin_create_or_overwrite(snap, value, alert_at_c)
-        _emit_admin(rec, snap)
+        alert_at = _parse_alert_at(args)
+        value = _random_value(args)
+        rec = write_value(
+            args,
+            value,
+            alert_at,
+            default_source=admin_source,
+            default_handed_over_by=handed_over_by,
+        )
+        _emit(rec, args)
         return 0
 
     return admin.as_user(args.user, _child, json_mode=args.json)
-
-
-def _parse_alert_at_raw(raw):
-    try:
-        return alerts.parse_date(raw)
-    except ValueError as exc:
-        raise ShushuError(EXIT_USER_ERROR, f"invalid date: {raw!r}", "use YYYY-MM-DD") from exc
-
-
-def _random_value_raw(nbytes, encoding):
-    try:
-        return gen.random_secret(nbytes=nbytes, encoding=encoding)
-    except ValueError as exc:
-        raise ShushuError(
-            EXIT_USER_ERROR, str(exc), "use positive --bytes and --encoding hex|base64"
-        ) from exc
-
-
-def _admin_create_or_overwrite(snap, value, alert_at_c):
-    """Create or regenerate under target uid (admin path).
-
-    Mirrors set's overwrite-immutability semantics: preserve hidden /
-    source / handed_over_by from the existing record on overwrite.
-    """
-    try:
-        existing = store.get_record(snap.name)
-    except store.NotFoundError:
-        existing = None
-    if existing is not None:
-        return store.set_secret(
-            name=snap.name,
-            value=value,
-            hidden=existing.hidden,
-            source=existing.source,
-            purpose=snap.purpose or existing.purpose,
-            rotation_howto=snap.rotate_howto or existing.rotation_howto,
-            alert_at=alert_at_c if alert_at_c is not None else existing.alert_at,
-            handed_over_by=existing.handed_over_by,
-        )
-    return store.set_secret(
-        name=snap.name,
-        value=value,
-        hidden=snap.hidden,
-        source=snap.source,
-        purpose=snap.purpose or "",
-        rotation_howto=snap.rotate_howto or "",
-        alert_at=alert_at_c,
-        handed_over_by=snap.handed_over_by,
-    )
-
-
-def _emit_admin(rec, snap):
-    """Admin-path emit: hidden suppresses value in both JSON and text."""
-    if snap.json_mode:
-        payload = {
-            "name": rec.name,
-            "hidden": rec.hidden,
-            "encoding": snap.encoding,
-            "bytes": snap.nbytes,
-        }
-        if not rec.hidden:
-            payload["value"] = rec.value
-        emit_result(payload, json_mode=True)
-        return
-    if rec.hidden:
-        print(f"shushu: generated {rec.name} (hidden, {snap.nbytes} bytes {snap.encoding})")
-    else:
-        print(f"shushu: generated {rec.name} ({snap.nbytes} bytes {snap.encoding})")
-        print(rec.value)
 
 
 def _check_admin_source_prefix(source) -> None:

--- a/src/shushu/cli/_commands/list_.py
+++ b/src/shushu/cli/_commands/list_.py
@@ -22,6 +22,7 @@ def handle(args) -> int:
 
 def _handle_all_users(args) -> int:
     import json as _json
+    import sys as _sys
 
     from shushu import admin
 
@@ -31,7 +32,12 @@ def _handle_all_users(args) -> int:
             data_raw = paths.file.read_text(encoding="utf-8")
         except OSError:
             return None
-        names = sorted(s["name"] for s in _json.loads(data_raw).get("secrets", []))
+        try:
+            raw = _json.loads(data_raw)
+            names = sorted(s["name"] for s in raw.get("secrets", []))
+        except (_json.JSONDecodeError, TypeError, KeyError) as exc:
+            _sys.stderr.write(f"shushu: warning: skipping {info.name}: corrupt store ({exc})\n")
+            return None
         return {"user": info.name, "names": names}
 
     rows = admin.for_each_user(_row)
@@ -62,4 +68,4 @@ def _handle_admin_user(args) -> int:
                 print(n)
         return 0
 
-    return admin.as_user(args.user, _child)
+    return admin.as_user(args.user, _child, json_mode=args.json)

--- a/src/shushu/cli/_commands/list_.py
+++ b/src/shushu/cli/_commands/list_.py
@@ -22,7 +22,6 @@ def handle(args) -> int:
 
 def _handle_all_users(args) -> int:
     import json as _json
-    import os as _os  # noqa: F401 — used for clarity; admin.for_each_user enforces root
 
     from shushu import admin
 

--- a/src/shushu/cli/_commands/list_.py
+++ b/src/shushu/cli/_commands/list_.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 from shushu import store
-from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
-    if getattr(args, "user", None) or getattr(args, "all_users", False):
-        raise ShushuError(
-            EXIT_USER_ERROR,
-            "list --user / --all-users not yet implemented",
-            "coming in Task 26",
-        )
+    if getattr(args, "all_users", False):
+        return _handle_all_users(args)
+    if getattr(args, "user", None):
+        return _handle_admin_user(args)
     names = store.list_names()
     if args.json:
         emit_result({"names": names}, json_mode=True)
@@ -21,3 +18,49 @@ def handle(args) -> int:
         for n in names:
             print(n)
     return 0
+
+
+def _handle_all_users(args) -> int:
+    import json as _json
+    import os as _os  # noqa: F401 — used for clarity; admin.for_each_user enforces root
+
+    from shushu import admin
+
+    def _row(info):
+        paths = admin.store_paths_for(info)
+        try:
+            data_raw = paths.file.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        names = sorted(s["name"] for s in _json.loads(data_raw).get("secrets", []))
+        return {"user": info.name, "names": names}
+
+    rows = admin.for_each_user(_row)
+    if args.json:
+        emit_result({"users": rows}, json_mode=True)
+    else:
+        for row in rows:
+            print(f"# {row['user']}")
+            for n in row["names"]:
+                print(n)
+    return 0
+
+
+def _handle_admin_user(args) -> int:
+    import os as _os
+
+    from shushu import admin
+
+    json_mode = args.json
+
+    def _child() -> int:
+        _os.environ.pop("SHUSHU_HOME", None)
+        names = store.list_names()
+        if json_mode:
+            emit_result({"names": names}, json_mode=True)
+        else:
+            for n in names:
+                print(n)
+        return 0
+
+    return admin.as_user(args.user, _child)

--- a/src/shushu/cli/_commands/overview.py
+++ b/src/shushu/cli/_commands/overview.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 from shushu import alerts, fs, store
-from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
-    if getattr(args, "user", None) or getattr(args, "all_users", False):
-        raise ShushuError(
-            EXIT_USER_ERROR,
-            "overview --user / --all-users not yet implemented",
-            "coming in Task 26",
-        )
+    if getattr(args, "all_users", False):
+        return _handle_all_users(args)
+    if getattr(args, "user", None):
+        return _handle_admin_user(args)
     # Read-only: don't trigger store-dir creation if no store exists yet.
     if not fs.user_store_paths().file.exists():
         data = store.StoreData(schema_version=store.SCHEMA_VERSION, secrets=[])
@@ -30,6 +27,88 @@ def handle(args) -> int:
     else:
         _render_text(records)
     return 0
+
+
+def _handle_all_users(args) -> int:
+    import json as _json
+
+    from shushu import admin
+
+    expired_only = getattr(args, "expired", False)
+
+    def _row(info):
+        paths = admin.store_paths_for(info)
+        try:
+            data_raw = paths.file.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        raw = _json.loads(data_raw)
+        records = []
+        for secret in raw.get("secrets", []):
+            alert_at_val = None
+            if secret.get("alert_at"):
+                try:
+                    from datetime import date
+
+                    alert_at_val = date.fromisoformat(secret["alert_at"])
+                except (ValueError, TypeError):
+                    pass
+            state = alerts.classify(alert_at_val)
+            if expired_only and state != "expired":
+                continue
+            records.append(
+                {
+                    "name": secret["name"],
+                    "hidden": secret.get("hidden", False),
+                    "source": secret.get("source", ""),
+                    "purpose": secret.get("purpose", ""),
+                    "rotation_howto": secret.get("rotation_howto", ""),
+                    "alert_at": secret.get("alert_at"),
+                    "alert_state": state,
+                    "handed_over_by": secret.get("handed_over_by"),
+                    "created_at": secret.get("created_at"),
+                    "updated_at": secret.get("updated_at"),
+                }
+            )
+        return {"user": info.name, "secrets": records}
+
+    rows = admin.for_each_user(_row)
+    if args.json:
+        emit_result({"ok": True, "users": rows}, json_mode=True)
+    else:
+        for row in rows:
+            print(f"# {row['user']}")
+            _render_text(row["secrets"])
+    return 0
+
+
+def _handle_admin_user(args) -> int:
+    import os as _os
+
+    from shushu import admin
+
+    expired_only = getattr(args, "expired", False)
+    json_mode = args.json
+
+    def _child() -> int:
+        _os.environ.pop("SHUSHU_HOME", None)
+        if not fs.user_store_paths().file.exists():
+            data = store.StoreData(schema_version=store.SCHEMA_VERSION, secrets=[])
+        else:
+            data = store.load()
+        records = []
+        for record in data.secrets:
+            state = alerts.classify(record.alert_at)
+            if expired_only and state != "expired":
+                continue
+            records.append(_record_to_dict(record, state))
+        if json_mode:
+            emit_result({"secrets": records}, json_mode=True)
+        else:
+            _render_text(records)
+        return 0
+
+    return admin.as_user(args.user, _child)
 
 
 def _record_to_dict(record, state):

--- a/src/shushu/cli/_commands/overview.py
+++ b/src/shushu/cli/_commands/overview.py
@@ -31,6 +31,7 @@ def handle(args) -> int:
 
 def _handle_all_users(args) -> int:
     import json as _json
+    import sys as _sys
 
     from shushu import admin
 
@@ -42,34 +43,13 @@ def _handle_all_users(args) -> int:
             data_raw = paths.file.read_text(encoding="utf-8")
         except OSError:
             return None
-        raw = _json.loads(data_raw)
-        records = []
-        for secret in raw.get("secrets", []):
-            alert_at_val = None
-            if secret.get("alert_at"):
-                try:
-                    from datetime import date
-
-                    alert_at_val = date.fromisoformat(secret["alert_at"])
-                except (ValueError, TypeError):
-                    pass
-            state = alerts.classify(alert_at_val)
-            if expired_only and state != "expired":
-                continue
-            records.append(
-                {
-                    "name": secret["name"],
-                    "hidden": secret.get("hidden", False),
-                    "source": secret.get("source", ""),
-                    "purpose": secret.get("purpose", ""),
-                    "rotation_howto": secret.get("rotation_howto", ""),
-                    "alert_at": secret.get("alert_at"),
-                    "alert_state": state,
-                    "handed_over_by": secret.get("handed_over_by"),
-                    "created_at": secret.get("created_at"),
-                    "updated_at": secret.get("updated_at"),
-                }
-            )
+        try:
+            raw = _json.loads(data_raw)
+            secrets_iter = list(raw.get("secrets", []))
+            records = _build_overview_records(secrets_iter, expired_only)
+        except (_json.JSONDecodeError, TypeError, KeyError) as exc:
+            _sys.stderr.write(f"shushu: warning: skipping {info.name}: corrupt store ({exc})\n")
+            return None
         return {"user": info.name, "secrets": records}
 
     rows = admin.for_each_user(_row)
@@ -108,7 +88,39 @@ def _handle_admin_user(args) -> int:
             _render_text(records)
         return 0
 
-    return admin.as_user(args.user, _child)
+    return admin.as_user(args.user, _child, json_mode=args.json)
+
+
+def _build_overview_records(secrets_iter, expired_only):
+    """Build overview rows from a list of raw secret dicts (--all-users path)."""
+    from datetime import date as _date
+
+    out = []
+    for secret in secrets_iter:
+        alert_at_val = None
+        if secret.get("alert_at"):
+            try:
+                alert_at_val = _date.fromisoformat(secret["alert_at"])
+            except (ValueError, TypeError):
+                pass
+        state = alerts.classify(alert_at_val)
+        if expired_only and state != "expired":
+            continue
+        out.append(
+            {
+                "name": secret["name"],
+                "hidden": secret.get("hidden", False),
+                "source": secret.get("source", ""),
+                "purpose": secret.get("purpose", ""),
+                "rotation_howto": secret.get("rotation_howto", ""),
+                "alert_at": secret.get("alert_at"),
+                "alert_state": state,
+                "handed_over_by": secret.get("handed_over_by"),
+                "created_at": secret.get("created_at"),
+                "updated_at": secret.get("updated_at"),
+            }
+        )
+    return out
 
 
 def _record_to_dict(record, state):

--- a/src/shushu/cli/_commands/set.py
+++ b/src/shushu/cli/_commands/set.py
@@ -15,7 +15,8 @@ from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
-    _check_admin(args)
+    if args.user is not None:
+        return _handle_admin_user(args)
     alert_at = _parse_alert_at(args)
     _check_admin_source_prefix(args.source)
     if args.value is not None:
@@ -26,15 +27,71 @@ def handle(args) -> int:
     return 0
 
 
-def _check_admin(args) -> None:
-    if args.user is None:
-        return
-    privilege.require_root(_rebuild_admin_tail(args))
-    raise ShushuError(
-        EXIT_USER_ERROR,
-        "set --user not yet implemented",
-        "coming in Task 26 (integration task)",
-    )
+def _handle_admin_user(args) -> int:
+    import os as _os
+
+    from shushu import admin
+
+    handed_over_by = privilege.sudo_invoker()
+    source = args.source or f"admin:{handed_over_by}"
+    # Snapshot all arg values needed inside the child closure.
+    arg_name = args.name
+    arg_value = args.value
+    arg_purpose = args.purpose
+    arg_rotate_howto = args.rotate_howto
+    arg_alert_at = args.alert_at
+    arg_hidden = args.hidden
+    json_mode = args.json
+
+    def _child() -> int:
+        _os.environ.pop("SHUSHU_HOME", None)
+        try:
+            alert_at_c = alerts.parse_date(arg_alert_at)
+        except ValueError as exc:
+            raise ShushuError(
+                EXIT_USER_ERROR,
+                f"invalid date: {arg_alert_at!r}",
+                "use YYYY-MM-DD",
+            ) from exc
+        if arg_value is None:
+            rec = store.update_metadata(
+                name=arg_name,
+                purpose=arg_purpose,
+                rotation_howto=arg_rotate_howto,
+                alert_at=alert_at_c,
+            )
+        else:
+            value_c = _read_value(arg_value)
+            try:
+                existing = store.get_record(arg_name)
+            except store.NotFoundError:
+                existing = None
+            if existing is not None:
+                rec = store.set_secret(
+                    name=arg_name,
+                    value=value_c,
+                    hidden=existing.hidden,
+                    source=existing.source,
+                    purpose=arg_purpose or existing.purpose,
+                    rotation_howto=arg_rotate_howto or existing.rotation_howto,
+                    alert_at=alert_at_c if alert_at_c is not None else existing.alert_at,
+                    handed_over_by=existing.handed_over_by,
+                )
+            else:
+                rec = store.set_secret(
+                    name=arg_name,
+                    value=value_c,
+                    hidden=arg_hidden,
+                    source=source,
+                    purpose=arg_purpose or "",
+                    rotation_howto=arg_rotate_howto or "",
+                    alert_at=alert_at_c,
+                    handed_over_by=handed_over_by,
+                )
+        _emit_ok(rec, json_mode)
+        return 0
+
+    return admin.as_user(args.user, _child)
 
 
 def _parse_alert_at(args):

--- a/src/shushu/cli/_commands/set.py
+++ b/src/shushu/cli/_commands/set.py
@@ -7,11 +7,31 @@ Without value: update mutable metadata only.
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass
 
 from shushu import alerts, privilege, store
 from shushu.cli._commands._write_helper import write_value
 from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 from shushu.cli._output import emit_result
+
+
+@dataclass(frozen=True)
+class _AdminSetSnapshot:
+    """Snapshot of args needed inside the admin fork-child closure.
+
+    Decouples the closure from the argparse Namespace so the child
+    holds only plain values (no shared mutable state with the parent).
+    """
+
+    name: str
+    value: str | None
+    purpose: str | None
+    rotate_howto: str | None
+    alert_at: str | None
+    hidden: bool
+    json_mode: bool
+    source: str
+    handed_over_by: str
 
 
 def handle(args) -> int:
@@ -33,65 +53,81 @@ def _handle_admin_user(args) -> int:
     from shushu import admin
 
     handed_over_by = privilege.sudo_invoker()
-    source = args.source or f"admin:{handed_over_by}"
+    admin_source = args.source or f"admin:{handed_over_by}"
     # Snapshot all arg values needed inside the child closure.
-    arg_name = args.name
-    arg_value = args.value
-    arg_purpose = args.purpose
-    arg_rotate_howto = args.rotate_howto
-    arg_alert_at = args.alert_at
-    arg_hidden = args.hidden
-    json_mode = args.json
+    snap = _AdminSetSnapshot(
+        name=args.name,
+        value=args.value,
+        purpose=args.purpose,
+        rotate_howto=args.rotate_howto,
+        alert_at=args.alert_at,
+        hidden=args.hidden,
+        json_mode=args.json,
+        source=admin_source,
+        handed_over_by=handed_over_by,
+    )
 
     def _child() -> int:
         _os.environ.pop("SHUSHU_HOME", None)
-        try:
-            alert_at_c = alerts.parse_date(arg_alert_at)
-        except ValueError as exc:
-            raise ShushuError(
-                EXIT_USER_ERROR,
-                f"invalid date: {arg_alert_at!r}",
-                "use YYYY-MM-DD",
-            ) from exc
-        if arg_value is None:
+        alert_at_c = _parse_alert_at_raw(snap.alert_at)
+        if snap.value is None:
             rec = store.update_metadata(
-                name=arg_name,
-                purpose=arg_purpose,
-                rotation_howto=arg_rotate_howto,
+                name=snap.name,
+                purpose=snap.purpose,
+                rotation_howto=snap.rotate_howto,
                 alert_at=alert_at_c,
             )
         else:
-            value_c = _read_value(arg_value)
-            try:
-                existing = store.get_record(arg_name)
-            except store.NotFoundError:
-                existing = None
-            if existing is not None:
-                rec = store.set_secret(
-                    name=arg_name,
-                    value=value_c,
-                    hidden=existing.hidden,
-                    source=existing.source,
-                    purpose=arg_purpose or existing.purpose,
-                    rotation_howto=arg_rotate_howto or existing.rotation_howto,
-                    alert_at=alert_at_c if alert_at_c is not None else existing.alert_at,
-                    handed_over_by=existing.handed_over_by,
-                )
-            else:
-                rec = store.set_secret(
-                    name=arg_name,
-                    value=value_c,
-                    hidden=arg_hidden,
-                    source=source,
-                    purpose=arg_purpose or "",
-                    rotation_howto=arg_rotate_howto or "",
-                    alert_at=alert_at_c,
-                    handed_over_by=handed_over_by,
-                )
-        _emit_ok(rec, json_mode)
+            rec = _admin_create_or_overwrite(snap, _read_value(snap.value), alert_at_c)
+        _emit_ok(rec, snap.json_mode)
         return 0
 
-    return admin.as_user(args.user, _child)
+    return admin.as_user(args.user, _child, json_mode=args.json)
+
+
+def _parse_alert_at_raw(raw):
+    try:
+        return alerts.parse_date(raw)
+    except ValueError as exc:
+        raise ShushuError(
+            EXIT_USER_ERROR,
+            f"invalid date: {raw!r}",
+            "use YYYY-MM-DD",
+        ) from exc
+
+
+def _admin_create_or_overwrite(snap, value, alert_at_c):
+    """Create or overwrite under target uid (admin path).
+
+    Mirrors `_write_helper.write_value`'s preserve-immutables semantics
+    but uses the admin-supplied `source` and `handed_over_by` defaults
+    on the create branch.
+    """
+    try:
+        existing = store.get_record(snap.name)
+    except store.NotFoundError:
+        existing = None
+    if existing is not None:
+        return store.set_secret(
+            name=snap.name,
+            value=value,
+            hidden=existing.hidden,
+            source=existing.source,
+            purpose=snap.purpose or existing.purpose,
+            rotation_howto=snap.rotate_howto or existing.rotation_howto,
+            alert_at=alert_at_c if alert_at_c is not None else existing.alert_at,
+            handed_over_by=existing.handed_over_by,
+        )
+    return store.set_secret(
+        name=snap.name,
+        value=value,
+        hidden=snap.hidden,
+        source=snap.source,
+        purpose=snap.purpose or "",
+        rotation_howto=snap.rotate_howto or "",
+        alert_at=alert_at_c,
+        handed_over_by=snap.handed_over_by,
+    )
 
 
 def _parse_alert_at(args):

--- a/src/shushu/cli/_commands/set.py
+++ b/src/shushu/cli/_commands/set.py
@@ -7,31 +7,11 @@ Without value: update mutable metadata only.
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass
 
 from shushu import alerts, privilege, store
 from shushu.cli._commands._write_helper import write_value
 from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 from shushu.cli._output import emit_result
-
-
-@dataclass(frozen=True)
-class _AdminSetSnapshot:
-    """Snapshot of args needed inside the admin fork-child closure.
-
-    Decouples the closure from the argparse Namespace so the child
-    holds only plain values (no shared mutable state with the parent).
-    """
-
-    name: str
-    value: str | None
-    purpose: str | None
-    rotate_howto: str | None
-    alert_at: str | None
-    hidden: bool
-    json_mode: bool
-    source: str
-    handed_over_by: str
 
 
 def handle(args) -> int:
@@ -40,7 +20,7 @@ def handle(args) -> int:
     alert_at = _parse_alert_at(args)
     _check_admin_source_prefix(args.source)
     if args.value is not None:
-        rec = _set_with_value(args, _read_value(args.value), alert_at)
+        rec = write_value(args, _read_value(args.value), alert_at)
     else:
         rec = _set_metadata_only(args, alert_at)
     _emit_ok(rec, args.json)
@@ -54,80 +34,24 @@ def _handle_admin_user(args) -> int:
 
     handed_over_by = privilege.sudo_invoker()
     admin_source = args.source or f"admin:{handed_over_by}"
-    # Snapshot all arg values needed inside the child closure.
-    snap = _AdminSetSnapshot(
-        name=args.name,
-        value=args.value,
-        purpose=args.purpose,
-        rotate_howto=args.rotate_howto,
-        alert_at=args.alert_at,
-        hidden=args.hidden,
-        json_mode=args.json,
-        source=admin_source,
-        handed_over_by=handed_over_by,
-    )
 
     def _child() -> int:
         _os.environ.pop("SHUSHU_HOME", None)
-        alert_at_c = _parse_alert_at_raw(snap.alert_at)
-        if snap.value is None:
-            rec = store.update_metadata(
-                name=snap.name,
-                purpose=snap.purpose,
-                rotation_howto=snap.rotate_howto,
-                alert_at=alert_at_c,
-            )
+        alert_at = _parse_alert_at(args)
+        if args.value is None:
+            rec = _set_metadata_only(args, alert_at)
         else:
-            rec = _admin_create_or_overwrite(snap, _read_value(snap.value), alert_at_c)
-        _emit_ok(rec, snap.json_mode)
+            rec = write_value(
+                args,
+                _read_value(args.value),
+                alert_at,
+                default_source=admin_source,
+                default_handed_over_by=handed_over_by,
+            )
+        _emit_ok(rec, args.json)
         return 0
 
     return admin.as_user(args.user, _child, json_mode=args.json)
-
-
-def _parse_alert_at_raw(raw):
-    try:
-        return alerts.parse_date(raw)
-    except ValueError as exc:
-        raise ShushuError(
-            EXIT_USER_ERROR,
-            f"invalid date: {raw!r}",
-            "use YYYY-MM-DD",
-        ) from exc
-
-
-def _admin_create_or_overwrite(snap, value, alert_at_c):
-    """Create or overwrite under target uid (admin path).
-
-    Mirrors `_write_helper.write_value`'s preserve-immutables semantics
-    but uses the admin-supplied `source` and `handed_over_by` defaults
-    on the create branch.
-    """
-    try:
-        existing = store.get_record(snap.name)
-    except store.NotFoundError:
-        existing = None
-    if existing is not None:
-        return store.set_secret(
-            name=snap.name,
-            value=value,
-            hidden=existing.hidden,
-            source=existing.source,
-            purpose=snap.purpose or existing.purpose,
-            rotation_howto=snap.rotate_howto or existing.rotation_howto,
-            alert_at=alert_at_c if alert_at_c is not None else existing.alert_at,
-            handed_over_by=existing.handed_over_by,
-        )
-    return store.set_secret(
-        name=snap.name,
-        value=value,
-        hidden=snap.hidden,
-        source=snap.source,
-        purpose=snap.purpose or "",
-        rotation_howto=snap.rotate_howto or "",
-        alert_at=alert_at_c,
-        handed_over_by=snap.handed_over_by,
-    )
 
 
 def _parse_alert_at(args):
@@ -156,10 +80,6 @@ def _read_value(v: str) -> str:
         # Preserve any other trailing newlines that are part of the secret.
         return sys.stdin.read().removesuffix("\n")
     return v
-
-
-def _set_with_value(args, value: str, alert_at):
-    return write_value(args, value, alert_at)
 
 
 def _set_metadata_only(args, alert_at):

--- a/src/shushu/cli/_commands/set.py
+++ b/src/shushu/cli/_commands/set.py
@@ -135,13 +135,6 @@ def _set_metadata_only(args, alert_at):
     )
 
 
-def _rebuild_admin_tail(args) -> str:
-    parts = ["set", "--user", args.user, args.name]
-    if args.value is not None:
-        parts.append(args.value)
-    return " ".join(parts)
-
-
 def _emit_ok(rec, json_mode: bool) -> None:
     if json_mode:
         emit_result(

--- a/src/shushu/cli/_commands/show.py
+++ b/src/shushu/cli/_commands/show.py
@@ -3,18 +3,35 @@
 from __future__ import annotations
 
 from shushu import store
-from shushu.cli._errors import EXIT_USER_ERROR, ShushuError
 from shushu.cli._output import emit_result
 
 
 def handle(args) -> int:
     if args.user is not None:
-        raise ShushuError(
-            EXIT_USER_ERROR,
-            "show --user not yet implemented",
-            "coming in Task 26",
-        )
+        return _handle_admin_user(args)
     rec = store.get_record(args.name)  # NotFoundError wrapped by main()
+    _emit_record(rec, args.json)
+    return 0
+
+
+def _handle_admin_user(args) -> int:
+    import os as _os
+
+    from shushu import admin
+
+    target_name = args.name
+    json_mode = args.json
+
+    def _child() -> int:
+        _os.environ.pop("SHUSHU_HOME", None)
+        rec = store.get_record(target_name)
+        _emit_record(rec, json_mode)
+        return 0
+
+    return admin.as_user(args.user, _child)
+
+
+def _emit_record(rec, json_mode: bool) -> None:
     payload = {
         "name": rec.name,
         "hidden": rec.hidden,
@@ -26,9 +43,8 @@ def handle(args) -> int:
         "created_at": rec.created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "updated_at": rec.updated_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
-    if args.json:
+    if json_mode:
         emit_result(payload, json_mode=True)
     else:
         for k, v in payload.items():
             print(f"{k}: {v}")
-    return 0

--- a/src/shushu/cli/_commands/show.py
+++ b/src/shushu/cli/_commands/show.py
@@ -28,7 +28,7 @@ def _handle_admin_user(args) -> int:
         _emit_record(rec, json_mode)
         return 0
 
-    return admin.as_user(args.user, _child)
+    return admin.as_user(args.user, _child, json_mode=json_mode)
 
 
 def _emit_record(rec, json_mode: bool) -> None:

--- a/src/shushu/cli/_translate.py
+++ b/src/shushu/cli/_translate.py
@@ -1,0 +1,58 @@
+"""Translate domain exceptions to ShushuError + exit code.
+
+Used by `cli.main` for top-level error handling AND by `admin.as_user`
+to translate exceptions raised inside fork-child closures so they
+produce the same structured error output as self-mode rather than
+being treated as EXIT_INTERNAL by `privilege.run_as_user`.
+
+Catches `ShushuError`, `store.ValidationError`, `store.NotFoundError`,
+`store.HiddenError`, and `store.StateError`. Lets every other exception
+bubble — `cli.main` adds its own broader handler (PrivilegeError,
+NotImplementedError, generic Exception with traceback). `admin.as_user`
+delegates to `privilege.run_as_user`'s generic catch for the unknown.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from shushu import store
+from shushu.cli._errors import EXIT_STATE, EXIT_USER_ERROR, ShushuError
+from shushu.cli._output import emit_error
+
+
+def translate_errors(fn: Callable[[], int], *, json_mode: bool) -> int:
+    """Run fn() and translate domain exceptions to ShushuError + exit code."""
+    try:
+        return fn()
+    except ShushuError as exc:
+        emit_error(exc, json_mode=json_mode)
+        return exc.code
+    except store.ValidationError as exc:
+        emit_error(
+            ShushuError(EXIT_USER_ERROR, str(exc), "see: shushu explain set"),
+            json_mode=json_mode,
+        )
+        return EXIT_USER_ERROR
+    except store.NotFoundError as exc:
+        emit_error(
+            ShushuError(EXIT_USER_ERROR, str(exc), "see: shushu list"),
+            json_mode=json_mode,
+        )
+        return EXIT_USER_ERROR
+    except store.HiddenError as exc:
+        emit_error(
+            ShushuError(EXIT_USER_ERROR, str(exc), "see: shushu run --inject"),
+            json_mode=json_mode,
+        )
+        return EXIT_USER_ERROR
+    except store.StateError as exc:
+        emit_error(
+            ShushuError(
+                EXIT_STATE,
+                str(exc),
+                "check your ~/.local/share/shushu/ for corruption",
+            ),
+            json_mode=json_mode,
+        )
+        return EXIT_STATE

--- a/src/shushu/privilege.py
+++ b/src/shushu/privilege.py
@@ -80,10 +80,17 @@ def run_as_user(user: UserInfo, fn: Callable[[], int]) -> int:
             rc = fn()
         except PrivilegeError as exc:
             sys.stderr.write(f"shushu: error: {exc.message}\n  → {exc.remediation}\n")
+            sys.stderr.flush()
             os._exit(66)
         except Exception as exc:  # pragma: no cover
             sys.stderr.write(f"shushu: internal error in admin handoff: {exc!r}\n")
+            sys.stderr.flush()
             os._exit(70)
+        # os._exit bypasses Python finalization, including atexit handlers and
+        # stdio buffer flushing. Flush explicitly so any print() output from
+        # fn() reaches the parent's captured pipe before the process exits.
+        sys.stdout.flush()
+        sys.stderr.flush()
         os._exit(rc)
     _, status = os.waitpid(pid, 0)
     if os.WIFEXITED(status):

--- a/src/shushu/privilege.py
+++ b/src/shushu/privilege.py
@@ -80,10 +80,12 @@ def run_as_user(user: UserInfo, fn: Callable[[], int]) -> int:
             rc = fn()
         except PrivilegeError as exc:
             sys.stderr.write(f"shushu: error: {exc.message}\n  → {exc.remediation}\n")
+            sys.stdout.flush()
             sys.stderr.flush()
             os._exit(66)
         except Exception as exc:  # pragma: no cover
             sys.stderr.write(f"shushu: internal error in admin handoff: {exc!r}\n")
+            sys.stdout.flush()
             sys.stderr.flush()
             os._exit(70)
         # os._exit bypasses Python finalization, including atexit handlers and

--- a/src/shushu/store.py
+++ b/src/shushu/store.py
@@ -87,6 +87,17 @@ def _record_to_json(r: SecretRecord) -> dict[str, Any]:
     }
 
 
+def record_from_json(d: dict[str, Any]) -> SecretRecord:
+    """Public API: parse a single secrets.json record dict into a SecretRecord.
+
+    Used by `doctor --all-users` (and any future read-side admin enumeration)
+    to validate other users' stores without going through `store.load()`,
+    which would acquire a lock. Raises `StateError` on schema violations
+    (non-bool `hidden`, missing required fields, etc.).
+    """
+    return _json_to_record(d)
+
+
 def _json_to_record(d: dict[str, Any]) -> SecretRecord:
     hidden_raw = d["hidden"]
     if not isinstance(hidden_raw, bool):

--- a/tests/integration/test_admin_handoff.py
+++ b/tests/integration/test_admin_handoff.py
@@ -1,0 +1,139 @@
+"""Integration tests that exercise real setuid-fork handoff.
+
+Gated: skip unless we're root OR SHUSHU_DOCKER=1 is set. CI runs these
+inside the disposable integration container.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import pwd
+import stat
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.geteuid() != 0 and not os.getenv("SHUSHU_DOCKER"),
+    reason="admin handoff requires root (CI runs this inside a container)",
+)
+
+
+@pytest.fixture(scope="module")
+def two_users():
+    """Create two throwaway OS users. Destroyed at module teardown."""
+    names = ["shushutest_alice", "shushutest_bob"]
+    for n in names:
+        subprocess.run(["useradd", "-m", n], check=True)
+    try:
+        yield names
+    finally:
+        for n in names:
+            subprocess.run(["userdel", "-r", n], check=False)
+
+
+def _shushu(*args, env=None):
+    return subprocess.run(
+        [sys.executable, "-m", "shushu", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_admin_set_writes_as_target_user(two_users):
+    alice, _bob = two_users
+    r = _shushu("set", "--user", alice, "FOO", "hunter2", "--purpose", "test")
+    assert r.returncode == 0, r.stderr
+    target = pathlib.Path(pwd.getpwnam(alice).pw_dir) / ".local/share/shushu/secrets.json"
+    assert target.exists()
+    st = target.stat()
+    assert stat.S_IMODE(st.st_mode) == 0o600
+    assert st.st_uid == pwd.getpwnam(alice).pw_uid
+    payload = json.loads(target.read_text())
+    rec = payload["secrets"][0]
+    assert rec["name"] == "FOO"
+    assert rec["value"] == "hunter2"
+    assert rec["source"].startswith("admin:")
+    assert rec["handed_over_by"]
+
+
+def test_admin_set_show_returns_metadata_only(two_users):
+    alice, _bob = two_users
+    # Ensure alice has FOO set (may already exist from prior test).
+    r = _shushu("set", "--user", alice, "FOO", "hunter2", "--purpose", "test")
+    assert r.returncode == 0, r.stderr
+    # Now run show --user alice FOO --json as root.
+    r = _shushu("show", "--user", alice, "FOO", "--json")
+    assert r.returncode == 0, r.stderr
+    payload = json.loads(r.stdout)
+    assert "value" not in payload
+    assert payload["source"].startswith("admin:")
+    assert payload["name"] == "FOO"
+
+
+def test_admin_generate_hidden_never_shows_value(two_users):
+    _alice, bob = two_users
+    r = _shushu("generate", "--user", bob, "BOBKEY", "--hidden", "--bytes", "32")
+    assert r.returncode == 0, r.stderr
+    target = pathlib.Path(pwd.getpwnam(bob).pw_dir) / ".local/share/shushu/secrets.json"
+    payload = json.loads(target.read_text())
+    # Find the BOBKEY record.
+    recs = [s for s in payload["secrets"] if s["name"] == "BOBKEY"]
+    assert recs, "BOBKEY not found in bob's store"
+    actual_value = recs[0]["value"]
+    # The actual value must never appear in stdout or stderr.
+    assert actual_value not in r.stdout
+    assert actual_value not in r.stderr
+
+
+def test_admin_delete_removes_secret(two_users):
+    alice, _bob = two_users
+    # Ensure TO_DELETE exists.
+    r = _shushu("set", "--user", alice, "TO_DELETE", "tempval", "--purpose", "temp")
+    assert r.returncode == 0, r.stderr
+    # Now delete it.
+    r = _shushu("delete", "--user", alice, "TO_DELETE")
+    assert r.returncode == 0, r.stderr
+    # Verify it's gone.
+    target = pathlib.Path(pwd.getpwnam(alice).pw_dir) / ".local/share/shushu/secrets.json"
+    payload = json.loads(target.read_text())
+    names = [s["name"] for s in payload["secrets"]]
+    assert "TO_DELETE" not in names
+
+
+def test_admin_list_user_returns_names(two_users):
+    alice, _bob = two_users
+    # Ensure alice has at least FOO.
+    r = _shushu("set", "--user", alice, "FOO", "hunter2", "--purpose", "test")
+    assert r.returncode == 0, r.stderr
+    r = _shushu("list", "--user", alice)
+    assert r.returncode == 0, r.stderr
+    assert "FOO" in r.stdout
+
+
+def test_target_user_can_inspect_not_admin_field(two_users):
+    alice, _ = two_users
+    _shushu("set", "--user", alice, "FOO", "v")
+    # Drop to alice and run show.
+    r = subprocess.run(
+        ["sudo", "-u", alice, sys.executable, "-m", "shushu", "show", "FOO", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    payload = json.loads(r.stdout)
+    assert "value" not in payload
+    assert payload["source"].startswith("admin:")
+
+
+def test_no_root_owned_files_left_behind(two_users):
+    """After the suite, no root-owned files under either user's home."""
+    for name in two_users:
+        home = pathlib.Path(pwd.getpwnam(name).pw_dir)
+        for path in home.rglob("*"):
+            st = path.stat()
+            assert st.st_uid != 0, f"root-owned leak at {path}"

--- a/tests/integration/test_admin_handoff.py
+++ b/tests/integration/test_admin_handoff.py
@@ -27,14 +27,21 @@ pytestmark = [
 
 @pytest.fixture(scope="module")
 def two_users():
-    """Create two throwaway OS users. Destroyed at module teardown."""
+    """Create two throwaway OS users. Destroyed at module teardown.
+
+    Track which users were *successfully* created so a partial-creation
+    failure (first useradd OK, second fails) still cleans up the first
+    on teardown instead of leaking it.
+    """
     names = ["shushutest_alice", "shushutest_bob"]
-    for n in names:
-        subprocess.run(["useradd", "-m", n], check=True)  # noqa: S603, S607
+    created: list[str] = []
     try:
+        for n in names:
+            subprocess.run(["useradd", "-m", n], check=True)  # noqa: S603, S607
+            created.append(n)
         yield names
     finally:
-        for n in names:
+        for n in reversed(created):
             subprocess.run(["userdel", "-r", n], check=False)  # noqa: S603, S607
 
 
@@ -140,3 +147,25 @@ def test_no_root_owned_files_left_behind(two_users):
         for path in home.rglob("*"):
             st = path.stat()
             assert st.st_uid != 0, f"root-owned leak at {path}"
+
+
+def test_admin_set_invalid_date_returns_user_error(two_users):
+    """Regression: ShushuError raised inside the admin fork-child must be
+    translated to its proper exit code (64), not swallowed by
+    privilege.run_as_user's generic Exception handler as EXIT_INTERNAL (70).
+    """
+    alice, _bob = two_users
+    r = _shushu("set", "--user", alice, "BADDATE", "v", "--alert-at", "not-a-date")
+    assert r.returncode == 64, f"got {r.returncode}, stderr: {r.stderr}"
+    assert "invalid date" in r.stderr.lower() or "yyyy-mm-dd" in r.stderr.lower()
+
+
+def test_admin_delete_missing_returns_user_error(two_users):
+    """Regression: store.NotFoundError raised inside the admin fork-child must
+    translate to exit 64 with the standard 'see: shushu list' remediation,
+    not EXIT_INTERNAL (70).
+    """
+    alice, _bob = two_users
+    r = _shushu("delete", "--user", alice, "NONEXISTENT_SECRET")
+    assert r.returncode == 64, f"got {r.returncode}, stderr: {r.stderr}"
+    assert "NONEXISTENT_SECRET" in r.stderr

--- a/tests/integration/test_admin_handoff.py
+++ b/tests/integration/test_admin_handoff.py
@@ -16,10 +16,13 @@ import sys
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    os.geteuid() != 0 and not os.getenv("SHUSHU_DOCKER"),
-    reason="admin handoff requires root (CI runs this inside a container)",
-)
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.geteuid() != 0 and not os.getenv("SHUSHU_DOCKER"),
+        reason="admin handoff requires root (CI runs this inside a container)",
+    ),
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_admin_handoff.py
+++ b/tests/integration/test_admin_handoff.py
@@ -11,7 +11,7 @@ import os
 import pathlib
 import pwd
 import stat
-import subprocess
+import subprocess  # noqa: S404
 import sys
 
 import pytest
@@ -27,16 +27,16 @@ def two_users():
     """Create two throwaway OS users. Destroyed at module teardown."""
     names = ["shushutest_alice", "shushutest_bob"]
     for n in names:
-        subprocess.run(["useradd", "-m", n], check=True)
+        subprocess.run(["useradd", "-m", n], check=True)  # noqa: S603, S607
     try:
         yield names
     finally:
         for n in names:
-            subprocess.run(["userdel", "-r", n], check=False)
+            subprocess.run(["userdel", "-r", n], check=False)  # noqa: S603, S607
 
 
 def _shushu(*args, env=None):
-    return subprocess.run(
+    return subprocess.run(  # noqa: S603
         [sys.executable, "-m", "shushu", *args],
         capture_output=True,
         text=True,
@@ -119,7 +119,7 @@ def test_target_user_can_inspect_not_admin_field(two_users):
     alice, _ = two_users
     _shushu("set", "--user", alice, "FOO", "v")
     # Drop to alice and run show.
-    r = subprocess.run(
+    r = subprocess.run(  # noqa: S603, S607
         ["sudo", "-u", alice, sys.executable, "-m", "shushu", "show", "FOO", "--json"],
         capture_output=True,
         text=True,

--- a/tests/integration/test_all_users_enumeration.py
+++ b/tests/integration/test_all_users_enumeration.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
+import subprocess  # noqa: S404
 import sys
 
 import pytest
@@ -24,9 +24,9 @@ _TEST_USER = "shushutest_carol"
 @pytest.fixture(scope="module")
 def carol_with_secret():
     """Create carol, write a secret as her, yield her name, then tear down."""
-    subprocess.run(["useradd", "-m", _TEST_USER], check=True)
+    subprocess.run(["useradd", "-m", _TEST_USER], check=True)  # noqa: S603, S607
     try:
-        subprocess.run(
+        subprocess.run(  # noqa: S603, S607
             [
                 "sudo",
                 "-u",
@@ -44,11 +44,11 @@ def carol_with_secret():
         )
         yield _TEST_USER
     finally:
-        subprocess.run(["userdel", "-r", _TEST_USER], check=False)
+        subprocess.run(["userdel", "-r", _TEST_USER], check=False)  # noqa: S603, S607
 
 
 def _shushu(*args):
-    return subprocess.run(
+    return subprocess.run(  # noqa: S603
         [sys.executable, "-m", "shushu", *args],
         capture_output=True,
         text=True,

--- a/tests/integration/test_all_users_enumeration.py
+++ b/tests/integration/test_all_users_enumeration.py
@@ -13,10 +13,13 @@ import sys
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    os.geteuid() != 0 and not os.getenv("SHUSHU_DOCKER"),
-    reason="requires root",
-)
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.geteuid() != 0 and not os.getenv("SHUSHU_DOCKER"),
+        reason="requires root",
+    ),
+]
 
 _TEST_USER = "shushutest_carol"
 

--- a/tests/integration/test_all_users_enumeration.py
+++ b/tests/integration/test_all_users_enumeration.py
@@ -1,0 +1,105 @@
+"""Integration tests for --all-users enumeration (list, overview, doctor).
+
+Gated: skip unless we're root OR SHUSHU_DOCKER=1 is set. CI runs these
+inside the disposable integration container.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.geteuid() != 0 and not os.getenv("SHUSHU_DOCKER"),
+    reason="requires root",
+)
+
+_TEST_USER = "shushutest_carol"
+
+
+@pytest.fixture(scope="module")
+def carol_with_secret():
+    """Create carol, write a secret as her, yield her name, then tear down."""
+    subprocess.run(["useradd", "-m", _TEST_USER], check=True)
+    try:
+        subprocess.run(
+            [
+                "sudo",
+                "-u",
+                _TEST_USER,
+                sys.executable,
+                "-m",
+                "shushu",
+                "set",
+                "SEC",
+                "supersecret",
+                "--purpose",
+                "test-secret",
+            ],
+            check=True,
+        )
+        yield _TEST_USER
+    finally:
+        subprocess.run(["userdel", "-r", _TEST_USER], check=False)
+
+
+def _shushu(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "shushu", *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_overview_all_users_never_exposes_value(carol_with_secret):
+    r = _shushu("overview", "--all-users", "--json")
+    assert r.returncode == 0, r.stderr
+    assert "supersecret" not in r.stdout
+    payload = json.loads(r.stdout)
+    assert payload["ok"] is True
+    users_rows = payload.get("users", [])
+    found = [row for row in users_rows if row.get("user") == _TEST_USER]
+    assert found, f"{_TEST_USER!r} not in overview output; users={[r['user'] for r in users_rows]}"
+    carol_row = found[0]
+    # Verify secrets metadata is present but value is absent.
+    secrets = carol_row.get("secrets", [])
+    assert secrets
+    for sec in secrets:
+        assert "value" not in sec
+
+
+def test_list_all_users_returns_names(carol_with_secret):
+    r = _shushu("list", "--all-users", "--json")
+    assert r.returncode == 0, r.stderr
+    payload = json.loads(r.stdout)
+    users_rows = payload.get("users", [])
+    found = [row for row in users_rows if row.get("user") == _TEST_USER]
+    assert found, f"{_TEST_USER!r} not found in list --all-users output"
+    assert "SEC" in found[0]["names"]
+
+
+def test_doctor_all_users_runs_checks(carol_with_secret):
+    r = _shushu("doctor", "--all-users", "--json")
+    assert r.returncode == 0, r.stderr
+    payload = json.loads(r.stdout)
+    users_rows = payload.get("users", [])
+    found = [row for row in users_rows if row.get("user") == _TEST_USER]
+    assert found, f"{_TEST_USER!r} not found in doctor --all-users output"
+    carol_row = found[0]
+    assert "checks" in carol_row
+    assert "summary" in carol_row
+    # schema_version check should pass.
+    sv_checks = [c for c in carol_row["checks"] if c["name"] == "schema_version"]
+    assert sv_checks
+    assert sv_checks[0]["status"] == "PASS"
+
+
+def test_list_all_users_text_mode(carol_with_secret):
+    r = _shushu("list", "--all-users")
+    assert r.returncode == 0, r.stderr
+    assert f"# {_TEST_USER}" in r.stdout
+    assert "SEC" in r.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "shushu"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Implements **admin mode** (`--user` / `--all-users`) for 7 verbs and brings
back the **integration test suite** with the CI `integration` job. After
this PR, `shushu --help` runs end-to-end in BOTH self-mode and admin-mode.

The single biggest task in the v1 plan by surface area + privilege-correctness
stakes — diff is 13 files / 766 LOC plus tests.

## Scope

| Verb | `--user` | `--all-users` | Behavior |
|---|---|---|---|
| `set`     | ✅ | — | Fork → drop uid → write target user's store. `source = args.source or "admin:<invoker>"`. `handed_over_by = sudo_invoker()` stamped on create, **preserved on overwrite** (no history erasure). |
| `generate`| ✅ | — | Same write path. `--hidden` continues to suppress value print/JSON in admin mode. |
| `show`    | ✅ | — | Fork → read metadata. Never `value`. |
| `delete`  | ✅ | — | Fork → delete from target store. |
| `list`    | ✅ | ✅ | `--user` forks; `--all-users` reads each user's `secrets.json` directly as root via `admin.for_each_user`. |
| `overview`| ✅ | ✅ | Same pattern; metadata snapshot per user, never `value`. |
| `doctor`  | ✅ | ✅ | Per-user store/file/schema check. |

**`get`, `env`, `run` deliberately have no admin paths** — H2 contract: admin can never extract a value through the CLI. Use `sudo cat` for plaintext.

## Architecture

New `src/shushu/admin.py` (~80 LOC):
- `as_user(name, fn)` — validates target OS user (raises `EXIT_BACKEND` on unknown), then delegates to `privilege.run_as_user(info, fn)`. Wraps `fn` to set `HOME = info.home` inside the child after the uid drop.
- `for_each_user(fn)` — root-only, no fork. Iterates `users.all_users()`, skips users with no home or no `secrets.json`, invokes `fn(info)` per user. Used for `--all-users` reads.
- `store_paths_for(info)` — computes `fs.StorePaths` for an arbitrary user's home (used by `for_each_user` callbacks to read directly).

Two `privilege.py` fixes caught by the integration suite:
- All `os._exit(...)` paths in `run_as_user` now flush stdout+stderr first. `subprocess.run(capture_output=True)` had been silently dropping the child's print() output.
- `admin.as_user` sets `HOME` in the child fork — without it, `Path.home()` resolved to root's HOME (inherited env) and `ensure_store_dir` raised `PermissionError`.

## Integration tests

New `tests/integration/` (gated by `SHUSHU_DOCKER=1` or `euid==0`):
- `test_admin_handoff.py` — 7 tests using real `useradd`/`userdel` for two users (alice, bob). Asserts file ownership, mode 0600, hidden-value non-disclosure across all admin paths, and **`test_no_root_owned_files_left_behind`** as the safety net.
- `test_all_users_enumeration.py` — 4 tests for `list --all-users`, `overview --all-users`, `doctor --all-users`. Asserts `value` is never in the JSON or stdout.

CI `integration` job re-introduced (was deleted in PR #3 due to the `if: hashFiles(...)` workflow-validation trap; `tests/integration/` now exists, so the job is unconditional).

## Test plan

- [x] `bash .claude/skills/run-tests/scripts/test.sh -p` — 114 unit pass + 11 integration skipped (correctly gated)
- [x] `docker build -f .github/workflows/Dockerfile.integration -t shushu-int .` — clean
- [x] `docker run --rm -e SHUSHU_DOCKER=1 shushu-int uv run pytest tests/integration -v` — 11/11 pass
- [x] `uv run flake8 / black --check / isort --check-only / bandit / pylint --errors-only` — all clean
- [x] `scripts/lint-md.sh` — 0 errors
- [x] `uv run shushu --version` → `shushu 0.7.0`
- [x] Self-mode smoke for set / list / delete unchanged
- [ ] CI green on PR head (incl. new `integration` job)

## Pushback notes

- **SonarCloud `docker:S6471`** (`USER root` in `Dockerfile.integration`) becomes active again with this PR. This is an established PUSHBACK from PR #2/#3 — same rationale: the Dockerfile is a per-CI-run disposable image whose sole purpose is to run integration tests that need real `useradd`/`userdel`. Header comment in the Dockerfile documents it. Will mark REVIEWED/SAFE in the SonarCloud UI after merge.
- **qodo `__version__`** → standard PUSHBACK, same as every prior PR.

Version bump: `0.6.0` → `0.7.0` (minor — major new capability).

## Out of scope

- `get` / `env` / `run` admin mode — by design (H2)
- Encryption-at-rest — Task 29
- Self-verify acceptance gate — Task 27 → PR #8
- Docs flesh-out — Task 28 → PR #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude