### PR TITLE
Release prep — spec-complete v0.8.0 (Tasks 27–29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,28 @@ with merged PRs per the per-PR version bump discipline documented in
 
 ## [Unreleased]
 
-- (nothing yet — v0.7.0 cut; next bump on the following PR)
+- (nothing yet — v0.8.0 cut; next bump on the following PR)
+
+## [0.8.0] — 2026-04-25 — v1 release-prep
+
+This is the **last PR of the v1 cycle**. After this lands, every verb
+in the design spec runs end-to-end (self-mode and admin-mode), the
+test pyramid has full unit + lifecycle + integration coverage, and
+the docs are production-shape. PRs after this start v1.x maintenance
+or v2 (encryption-at-rest) work.
+
+### Added
+
+- `tests/test_self_verify.py` — single 13-step end-to-end lifecycle test that walks every verb against a fresh `tmp_path` store, asserting the H2 hidden contract holds across set / generate / show / get / env / run / list / delete / doctor / overview / metadata-only update / immutable refusal. Acts as the squash-merge-blocking acceptance gate. Uses the shared `cli_run` fixture from `tests/conftest.py`. The single subprocess call (step 8, `run --inject`) exists because `os.execvpe` would otherwise replace the pytest process.
+- `docs/threat-model.md` (full) — expands spec §8 into a self-contained threat-model statement: trust boundary, adversary model (5 must-prevents for non-root local users), 6 risk surfaces (setuid-fork handoff, file-mode drift, hidden-secret CLI contract, admin metadata exfiltration, command-line argument leakage, input validation), residual-risks table, link to the encryption-at-rest tracking issue.
+- `docs/rubric-mapping.md` (full) — per-verb reference: exit-code table (0 / 64 / 65 / 66 / 67 / 70), JSON success envelope (`{"ok": true, ...}`), one section per verb covering purpose, exit codes with reasons, and JSON payload shape. Ends with the admin-flag matrix and the rationale for why `get` / `env` / `run` are deliberately admin-flag-free.
+- `README.md` — full rewrite. Stdin-form (`shushu set FOO -`) is the canonical example to keep values out of `/proc/<pid>/cmdline` and shell history. H2 contract spelled out. Admin handoff section. Exit-code table.
+- `CLAUDE.md` — full rewrite. Post-v1 orientation: complete src layout, common commands using the run-tests / pr-review skill scripts, version discipline, the H2 contract as non-negotiable, trust boundary, recurring PR-pushback rules.
+- `docs/testing.md` — extended with the test pyramid section (unit → self-verify → integration) and the run-tests wrapper invocation matrix.
+
+### Changed
+
+- Version bumped `0.7.0 → 0.8.0`. Continues the per-PR minor cadence (1.0.0 deferred — see Out of scope).
 
 ## [0.7.0] — 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@ with merged PRs per the per-PR version bump discipline documented in
 
 - (nothing yet — v0.8.0 cut; next bump on the following PR)
 
-## [0.8.0] — 2026-04-25 — v1 release-prep
+## [0.8.0] — 2026-04-25 — spec-complete release-prep
 
-This is the **last PR of the v1 cycle**. After this lands, every verb
-in the design spec runs end-to-end (self-mode and admin-mode), the
-test pyramid has full unit + lifecycle + integration coverage, and
-the docs are production-shape. PRs after this start v1.x maintenance
-or v2 (encryption-at-rest) work.
+This is the **last PR of the spec-complete cycle on the 0.x line**.
+After this lands, every verb in the design spec runs end-to-end
+(self-mode and admin-mode), the test pyramid has full unit +
+lifecycle + integration coverage, and the docs are production-shape.
+PRs after this start 0.x maintenance work or v1.x feature work
+(encryption-at-rest is tracked at
+[issue #8](https://github.com/agentculture/shushu/issues/8)).
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,56 +1,172 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file orients Claude Code (claude.ai/code) when working in this
+repository.
 
 ## Project status
 
-`shushu` is an early-stage **uv-managed Python CLI**. The scaffold is intentionally minimal — argparse-based entry point, no runtime dependencies yet. Expect this file to grow as the CLI's actual purpose and subcommands are added.
+`shushu` is the **agent-first per-OS-user secrets manager CLI** for
+the AgentCulture ecosystem. v1 surface is complete: 12 verbs (set,
+generate, show, get, env, run, list, delete, overview, doctor,
+learn, explain) with admin-mode (`--user` / `--all-users`) for the
+seven verbs that admit it. Sibling to
+[`zehut`](https://github.com/agentculture/zehut) (identity layer);
+patterned on [`afi-cli`](https://github.com/agentculture/afi-cli).
 
-Remote: `https://github.com/OriNachum/shushu`
+Remote: `https://github.com/agentculture/shushu`.
 
 ## Layout
 
 ```text
-src/shushu/          # package (src-layout)
-  __init__.py        # exports __version__
-  __main__.py        # enables `python -m shushu`
-  cli.py             # argparse entry point — main() is the console_script target
-tests/               # pytest suite
-pyproject.toml       # hatchling build; [project.scripts] shushu = shushu.cli:main
+src/shushu/
+  __init__.py            # __version__ via importlib.metadata
+  __main__.py            # enables `python -m shushu`
+  fs.py                  # paths, fcntl locking, atomic write
+  alerts.py              # alert_at classification (ok/alerting/expired)
+  generate.py            # random_secret(hex|base64)
+  users.py               # UserInfo, resolve(name), all_users()
+  privilege.py           # require_root, sudo_invoker, run_as_user (setuid-fork)
+  store.py               # JSON CRUD; SecretRecord; immutability rules
+  admin.py               # as_user / for_each_user / store_paths_for
+  cli/
+    __init__.py          # argparse parser; main() with error translation
+    _errors.py           # ShushuError + EXIT_* constants
+    _output.py           # emit_result / emit_error (text + json)
+    _translate.py        # exception → ShushuError translation (used by main + admin)
+    _commands/
+      _write_helper.py   # shared create-or-overwrite (set + generate)
+      <verb>.py          # one per verb
+tests/
+  conftest.py            # autouse _tmp_home + cli_run fixture
+  test_cli.py            # --version
+  test_self_verify.py    # 13-step end-to-end lifecycle (acceptance gate)
+  unit/                  # per-module + per-verb unit tests
+  integration/           # gated SHUSHU_DOCKER=1; useradd + setuid-fork
+.github/workflows/
+  tests.yml              # lint / unit / integration / version-check
+  Dockerfile.integration # disposable USER root image for integration tests
+docs/
+  threat-model.md        # full threat model (expands spec §8)
+  rubric-mapping.md      # per-verb purpose / exit codes / JSON shape
+  testing.md             # test pyramid + smoke convention
+  superpowers/           # design spec + implementation plan (one-time)
+.claude/skills/
+  pr-review/             # vendored: pr-status.sh adds CI + sonar overview
+  run-tests/             # vendored: --clean / --clean-smoke / --smoke-home
+  version-bump/          # vendored: bump.py for pyproject + CHANGELOG
 ```
 
-The console script **`shushu`** is registered in `pyproject.toml` and resolves to `shushu.cli:main`. Keep that wiring intact when refactoring — the CLI is the product.
+The console script `shushu` is registered in `pyproject.toml` and
+resolves to `shushu.cli:main`.
 
 ## Common commands
 
 ```bash
-uv venv                         # create .venv
-uv pip install -e ".[dev]"      # editable install with dev extras
-uv run shushu --version         # smoke-test the installed entry point
-uv run pytest                   # run the full suite
-uv run pytest tests/test_cli.py::test_version_flag   # run a single test
-uv run pytest -k version        # run tests matching an expression
+# unit + self-verify (skips integration without SHUSHU_DOCKER)
+bash .claude/skills/run-tests/scripts/test.sh -p
+
+# CI parity: parallel + coverage + xml + verbose
+bash .claude/skills/run-tests/scripts/test.sh --ci
+
+# integration only, inside Docker (needs root for useradd)
+docker build -f .github/workflows/Dockerfile.integration -t shushu-int .
+docker run --rm -e SHUSHU_DOCKER=1 shushu-int uv run pytest tests/integration -v
+
+# smoke: per-namespace tmp + cleanup, no manual rm
+SMOKE=$(bash .claude/skills/run-tests/scripts/test.sh --smoke-home foo)
+bash .claude/skills/run-tests/scripts/test.sh --clean-smoke foo
+SHUSHU_HOME="$SMOKE" uv run shushu set FOO bar --purpose t
+bash .claude/skills/run-tests/scripts/test.sh --clean-smoke foo
+
+# PR status (combines gh pr checks + sonar API + thread tally)
+bash .claude/skills/pr-review/scripts/pr-status.sh <PR>
 ```
 
 ## Lint / format
 
-Dev extras include `black`, `isort`, and `flake8`. Config (line length 100, py310 target) lives in `pyproject.toml`.
+Dev extras: `black`, `isort`, `flake8`, `flake8-bandit`,
+`flake8-bugbear`, `pylint`, `bandit`. Line length 100, target py312.
 
 ```bash
-uv run black src tests
-uv run isort src tests
-uv run flake8 src tests
+uv run black src/shushu tests
+uv run isort src/shushu tests
+uv run flake8 src/shushu tests
+uv run bandit -r src/shushu -c pyproject.toml
+uv run pylint --errors-only src/shushu
+scripts/lint-md.sh
 ```
+
+`.flake8` carries the only per-file ignores (`tests/*:S101`). Don't
+broaden it — real dead imports get deleted, not suppressed.
 
 ## Version discipline
 
-Version is declared in **two places that must stay in sync**:
+Version lives in **one place**: `pyproject.toml`'s `[project].version`.
+`src/shushu/__init__.py` resolves `__version__` dynamically via
+`importlib.metadata.version("shushu")`. No literal in `__init__.py`
+to keep in sync.
 
-- `pyproject.toml` → `[project].version`
-- `src/shushu/__init__.py` → `__version__`
-
-`cli.py` reads `__version__` from the package and surfaces it via `--version`, and `test_default_prints_version` asserts the two agree. Bump both together.
+The `version-bump` skill at
+`.claude/skills/version-bump/scripts/bump.py` automates the bump +
+CHANGELOG entry. Every PR must bump (`major` / `minor` / `patch`) —
+the `version-check` CI job blocks merge otherwise.
 
 ## Python version
 
-`requires-python = ">=3.10"`. `cli.py` uses PEP 604 union syntax (`Sequence[str] | None`) and `from __future__ import annotations` — don't lower the floor without revisiting those.
+`requires-python = ">=3.12"`. PEP 604 union syntax and frozen
+dataclasses are used throughout. Don't lower the floor.
+
+## Hidden-secret contract (H2) — non-negotiable
+
+`hidden: true` records:
+
+- Are immutable post-create (no toggling).
+- Are refused by `get`, `env`, `show` (exit 64).
+- Are omitted from `generate --hidden --json` output (no `value` key).
+- Are consumable ONLY via `shushu run --inject VAR=NAME -- cmd`.
+- Admin paths inherit ALL of the above — admin can never extract a
+  value via the CLI, even for root.
+
+`get`, `env`, `run` deliberately have NO admin flags. `run` is the
+only consumer for hidden secrets; it execs the child without ever
+passing the value on the command line.
+
+If you're tempted to add a "show value" path for admin, stop —
+that's the contract. Use `sudo cat ~user/.local/share/shushu/secrets.json`
+if you truly need plaintext (at which point you're outside shushu's
+surface).
+
+## Trust boundary
+
+shushu is **single-admin trusted-host**. Multi-tenant hosts, network
+services, and remote attackers are out of scope. The threat model at
+[`docs/threat-model.md`](docs/threat-model.md) is the source of truth
+for what shushu does and does not protect against.
+
+## PR workflow
+
+Every PR follows the same loop:
+
+1. Branch off `main` (e.g. `feat/<short>` or `fix/<short>`).
+2. Implement + test locally.
+3. Bump version (skill above).
+4. Open PR.
+5. After CI completes, run
+   `bash .claude/skills/pr-review/scripts/pr-status.sh <PR>`. The
+   script surfaces failed CI checks, SonarCloud quality-gate status
+   with rule keys, per-bot review-pipeline state, and inline-thread
+   tally — much faster than chasing each piece individually.
+6. Triage (FIX / PUSHBACK), commit fixes, reply + resolve threads
+   via `pr-review` skill scripts.
+7. Squash-merge.
+
+Recurring PUSHBACKs (already user-approved on prior PRs):
+
+- qodo `__version__` rule violation — `importlib.metadata` is
+  strictly stronger than two synced literals. Reply with that
+  rationale and resolve.
+- SonarCloud `docker:S6471` (USER root in
+  `.github/workflows/Dockerfile.integration`) — disposable per-CI-run
+  image, sole purpose is integration tests needing real
+  `useradd`/`userdel`. Mark REVIEWED/SAFE in SonarCloud UI after
+  merge.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,143 @@
 # shushu
 
-A Python CLI. Early scaffold — details to come.
+Agent-first per-OS-user secrets manager CLI. Part of the
+[AgentCulture](https://github.com/agentculture) ecosystem; sibling to
+[`zehut`](https://github.com/agentculture/zehut) (identity layer) and
+patterned on [`afi-cli`](https://github.com/agentculture/afi-cli)
+(noun-verb shape, exit-code discipline, structured `--json` output).
 
-## Install (dev)
+Each OS user gets their own secrets store at
+`~/.local/share/shushu/secrets.json` (mode `0600`, owned by the
+user). shushu never reaches across users in self-mode. Admin handoff
+to another user goes through a single `setuid-fork` chokepoint and
+preserves the H2 hidden-secret contract — admin can never extract a
+value through any CLI verb.
 
-```bash
-uv venv
-uv pip install -e ".[dev]"
-```
-
-## Run
-
-```bash
-uv run shushu --version
-```
-
-## Test
+## Install
 
 ```bash
-uv run pytest
+uv tool install shushu
+shushu --version
 ```
+
+Linux only (uses `setuid` / `useradd` semantics). Python ≥ 3.12.
+
+## Quick start
+
+```bash
+# store a secret you already have (stdin form preferred — keeps the
+# value out of /proc/<pid>/cmdline and shell history)
+echo -n "sk-..." | shushu set OPENAI_API_KEY -
+
+# generate a random one, hidden — never printed
+shushu generate JWT_SECRET --bytes 32 --hidden
+
+# inspect (never prints value)
+shushu show OPENAI_API_KEY
+shushu show OPENAI_API_KEY --json
+
+# consume — visible secrets only
+shushu get OPENAI_API_KEY
+eval $(shushu env OPENAI_API_KEY DATABASE_URL)
+
+# consume — visible OR hidden (this is the only path for hidden)
+shushu run --inject JWT=JWT_SECRET --inject DB=DATABASE_URL -- ./myapp
+```
+
+`shushu list` and `shushu overview` give names and metadata.
+`shushu delete NAME` removes a record.
+
+## Self-teaching surface
+
+```bash
+shushu learn                # markdown summary of every verb + concept
+shushu learn --json         # structured payload for agent consumers
+shushu explain hidden       # explain a concept
+shushu explain set          # explain a verb
+```
+
+## Admin handoff
+
+shushu is single-admin-trusted-host. Admin operations go through
+`sudo`; the binary forks → drops to the target user → writes/reads
+under their uid. Every admin write stamps `source = "admin:<invoker>"`
+and `handed_over_by = "<invoker>"` so the receiving user can audit.
+
+```bash
+# provision a secret into alice's store as root
+sudo shushu set --user alice OPENAI_API_KEY -
+
+# read-only audit across every user with a shushu store
+sudo shushu overview --all-users
+sudo shushu doctor --all-users
+
+# delete a record from alice's store
+sudo shushu delete --user alice OPENAI_API_KEY
+```
+
+`get`, `env`, `run` deliberately have NO admin flags — values are
+never extractable through the CLI, even for root. Use `sudo cat
+~alice/.local/share/shushu/secrets.json` if you truly need plaintext
+(at which point you've moved outside shushu's contract).
+
+## Hidden secrets — the H2 contract
+
+A secret with `hidden: true`:
+
+- Is **immutable post-create** — you cannot toggle the hidden flag.
+- Is **refused** by `get`, `env`, `show` (they exit `64` with a
+  remediation pointing at `run --inject`).
+- Has its value **omitted** from `generate --hidden --json` output
+  (the JSON payload has no `value` field).
+- Is consumable **only** through `shushu run --inject VAR=NAME -- cmd`.
+
+Hidden is a CLI contract, not encryption. The on-disk file is
+plaintext at `0600`. Encryption-at-rest is tracked for v2.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | success |
+| `64` | bad input from the caller (invalid flag, missing record, hidden refusal, etc.) |
+| `65` | store is corrupt / schema mismatch / unreadable |
+| `66` | this operation requires root |
+| `67` | backend dependency failed (unknown OS user, etc.) |
+| `70` | bug in shushu — please file an issue |
+
+Every error path emits a structured `ShushuError` with a remediation
+string. With `--json`, errors land as `{"ok": false, "error": {...}}`
+on stdout (single-payload contract).
+
+## Docs
+
+- [Design spec](docs/superpowers/specs/2026-04-24-shushu-secrets-cli-design.md)
+- [Threat model](docs/threat-model.md)
+- [Per-verb rubric mapping](docs/rubric-mapping.md)
+- [Testing notes](docs/testing.md)
+- [CHANGELOG](CHANGELOG.md)
+
+## Development
+
+```bash
+git clone https://github.com/agentculture/shushu
+cd shushu
+uv sync                                                         # install deps
+bash .claude/skills/run-tests/scripts/test.sh -p                # unit suite
+bash .claude/skills/run-tests/scripts/test.sh --ci              # CI parity
+```
+
+Integration tests need real root + `useradd`/`userdel`, which we
+only do inside a disposable Docker image:
+
+```bash
+docker build -f .github/workflows/Dockerfile.integration -t shushu-int .
+docker run --rm -e SHUSHU_DOCKER=1 shushu-int uv run pytest tests/integration -v
+```
+
+See [docs/testing.md](docs/testing.md) for the broader test-isolation
+conventions and the smoke-test namespace under `/tmp/shushu-tests/`.
+
+## License
+
+MIT. © 2026 Ori Nachum / AgentCulture.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ A secret with `hidden: true`:
 - Is consumable **only** through `shushu run --inject VAR=NAME -- cmd`.
 
 Hidden is a CLI contract, not encryption. The on-disk file is
-plaintext at `0600`. Encryption-at-rest is tracked for v2.
+plaintext at `0600`. Encryption-at-rest is tracked for a future
+v1.x release in
+[issue #8](https://github.com/agentculture/shushu/issues/8).
 
 ## Exit codes
 

--- a/docs/rubric-mapping.md
+++ b/docs/rubric-mapping.md
@@ -58,8 +58,10 @@ Read-only setup / permission / schema integrity checks.
 
 - `0` if no FAIL checks.
 - `65` (`EXIT_STATE`) if any FAIL check.
-- `64` if `--user` / `--all-users` and the operation is not yet
-  applicable (or, in self-mode, if the flags are passed without sudo).
+- `66` (`EXIT_PRIVILEGE`) if `--user` / `--all-users` is passed
+  without root.
+- `67` (`EXIT_BACKEND`) if `--user NAME` resolves to an unknown OS
+  user.
 
 JSON success:
 

--- a/docs/rubric-mapping.md
+++ b/docs/rubric-mapping.md
@@ -1,5 +1,256 @@
 # shushu afi-rubric mapping
 
-(Stub — full content lands in Task 28. Maps shushu's CLI to the
-afi-cli rubric: `learn`, `explain`, exit-code policy, per-verb JSON
-payload schemas.)
+Per-verb reference for shushu's 12 CLI verbs: purpose, exit codes,
+and the structured JSON success payload. shushu follows the
+[afi-cli](https://github.com/agentculture/afi-cli) rubric for
+agent-first CLIs (noun-verb shape, structured `--json` output, exit
+codes from sysexits.h with named constants).
+
+## Exit codes (the `EXIT_*` constants)
+
+| Code | Name | Meaning |
+|---|---|---|
+| 0 | `EXIT_SUCCESS` | OK |
+| 64 | `EXIT_USER_ERROR` | Bad input from the caller — invalid flag, malformed value, missing record, refused (e.g. hidden), unknown topic |
+| 65 | `EXIT_STATE` | Store on disk is corrupt or in an unexpected state |
+| 66 | `EXIT_PRIVILEGE` | This operation requires root and the process is not root |
+| 67 | `EXIT_BACKEND` | Backend dependency failed (unknown OS user, child process died abnormally) |
+| 70 | `EXIT_INTERNAL` | Bug in shushu — file an issue |
+
+Every error path emits a structured ShushuError with a remediation
+string that points the user at the next step.
+
+## JSON success envelope
+
+All `--json` outputs are wrapped in `{"ok": true, ...}` for success and
+`{"ok": false, "error": {...}}` for errors. The per-verb payloads below
+list the keys that appear inside the `ok: true` envelope.
+
+---
+
+## Globals
+
+### learn
+
+Print the agent-authored summary of every verb + concept.
+
+- `0` — always.
+
+JSON:
+
+```json
+{"ok": true, "verbs": ["delete", "doctor", ...], "descriptions": {"set": "...", ...}, "concepts": ["..."]}
+```
+
+### explain `<topic>`
+
+Print short markdown docs for a verb or concept (e.g. `hidden`,
+`admin`, `alert_at`).
+
+- `0` on known topic.
+- `64` on unknown topic — remediation lists the canonical topic set.
+
+JSON: not applicable (text output is markdown).
+
+### doctor
+
+Read-only setup / permission / schema integrity checks.
+
+- `0` if no FAIL checks.
+- `65` (`EXIT_STATE`) if any FAIL check.
+- `64` if `--user` / `--all-users` and the operation is not yet
+  applicable (or, in self-mode, if the flags are passed without sudo).
+
+JSON success:
+
+```json
+{
+  "ok": true,
+  "checks": [{"name": "store_dir", "status": "PASS", "detail": "..."}, ...],
+  "summary": {"pass": 2, "warn": 0, "fail": 0}
+}
+```
+
+`--all-users` adds a `users` outer array with one entry per
+inspected user.
+
+### overview
+
+Rich metadata snapshot with alert classification (`ok` / `alerting` /
+`expired`). Never includes `value`.
+
+- `0` always (empty store is fine).
+- `64` if user-supplied flags are invalid.
+
+JSON success:
+
+```json
+{"ok": true, "secrets": [{"name": "FOO", "hidden": false, "source": "localhost",
+                          "purpose": "...", "alert_state": "ok", ...}, ...]}
+```
+
+`--all-users` outer shape: `{"ok": true, "users": [{"user": "...", "secrets": [...]}, ...]}`.
+
+---
+
+## Write surface
+
+### set `NAME [VALUE] [flags]`
+
+With `VALUE`: create or update. Without `VALUE`: metadata-only update.
+Use `-` for `VALUE` to read from stdin (preferred for real secrets).
+
+- `0` on success (record stored or metadata updated).
+- `64` on bad input: invalid name, invalid `--alert-at`, immutable
+  field change attempt, `--source admin:*` from non-admin path.
+- `66` on `--user` from non-root.
+
+JSON success:
+
+```json
+{"ok": true, "name": "FOO", "hidden": false, "updated_at": "2026-04-25T12:34:56Z"}
+```
+
+### generate `NAME [--bytes N] [--encoding hex|base64] [flags]`
+
+Random secret. Default 32 bytes hex. `--hidden` never prints the
+value.
+
+- `0` on success.
+- `64` on invalid `--bytes`, invalid `--encoding`, or invalid
+  `--alert-at`.
+
+JSON success (visible):
+
+```json
+{"ok": true, "name": "FOO", "hidden": false, "encoding": "hex", "bytes": 32, "value": "..."}
+```
+
+JSON success (hidden — `value` field is absent):
+
+```json
+{"ok": true, "name": "FOO", "hidden": true, "encoding": "hex", "bytes": 32}
+```
+
+### delete `NAME`
+
+Remove a secret.
+
+- `0` on success.
+- `64` if `NAME` does not exist.
+
+JSON success:
+
+```json
+{"ok": true, "name": "FOO", "deleted": true}
+```
+
+---
+
+## Read surface
+
+### show `NAME [--json]`
+
+Print metadata for a secret. **Never** prints `value`.
+
+- `0` on success.
+- `64` if `NAME` does not exist.
+
+JSON success:
+
+```json
+{"ok": true, "name": "FOO", "hidden": false, "source": "localhost",
+ "purpose": "...", "rotation_howto": "...", "alert_at": null,
+ "handed_over_by": null,
+ "created_at": "2026-04-25T12:34:56Z",
+ "updated_at": "2026-04-25T12:34:56Z"}
+```
+
+### get `NAME`
+
+Print value to stdout. **Refused if hidden.** Deliberately does NOT
+register `--user` / `--all-users` — admin cannot extract values via
+the CLI (H2 contract). For plaintext as root, use `sudo cat`.
+
+- `0` on success.
+- `64` if `NAME` does not exist OR is hidden (remediation points at
+  `shushu run --inject`).
+
+JSON success:
+
+```json
+{"ok": true, "name": "FOO", "value": "..."}
+```
+
+### env `NAME1 [NAME2 ...]`
+
+POSIX-quoted `export` lines for `eval $(shushu env A B)`. **Refuses
+the whole call** if any named secret is hidden. Like `get`, no admin
+flags.
+
+- `0` on success.
+- `64` if any `NAME` does not exist OR is hidden.
+
+Output is shell text, not JSON:
+
+```sh
+export FOO='value'
+export BAR='other value'
+```
+
+### run `--inject VAR=NAME [...] -- cmd [args]`
+
+Fork-exec via `os.execvpe` with the secret stamped into env as `VAR`.
+**Both visible and hidden secrets allowed** — `run --inject` is the
+ONLY consumer for hidden secrets. Last-wins on duplicate VAR. No
+admin flags.
+
+- `0` from the child if the child returned `0`; otherwise the child's
+  exit code.
+- `64` on malformed `--inject` (missing `=`, empty VAR, empty NAME),
+  unknown secret name, missing `--`, or command not found.
+
+Output is whatever the child wrote to stdout/stderr.
+
+### list
+
+Names only, sorted, one per line.
+
+- `0` always.
+
+JSON success:
+
+```json
+{"ok": true, "names": ["BAR", "FOO"]}
+```
+
+`--all-users` outer shape: `{"ok": true, "users": [{"user": "...", "names": [...]}, ...]}`.
+
+---
+
+## Admin verbs (`--user` / `--all-users`)
+
+Admin verbs route through `setuid-fork`
+(`shushu.privilege.run_as_user` plus `shushu.admin.as_user`). The
+fork-child runs as the target user, sets `HOME` correctly, and
+translates `ShushuError` + `store.*` exceptions to the standard exit
+codes via `cli._translate.translate_errors`.
+
+`get`, `env`, `run` are deliberately admin-flag-free. The H2
+hidden-secret contract is preserved: admin (including root) cannot
+extract a value through any CLI verb.
+
+| Verb | `--user` | `--all-users` | Why |
+|---|---|---|---|
+| `set`     | yes | — | write only into one user's store |
+| `generate`| yes | — | write only into one user's store |
+| `show`    | yes | — | metadata-only read of one user |
+| `delete`  | yes | — | write only into one user's store |
+| `list`    | yes | yes | enumerate names |
+| `overview`| yes | yes | enumerate metadata |
+| `doctor`  | yes | yes | check store integrity per user |
+| `get`     | no  | no | values not extractable via CLI |
+| `env`     | no  | no | values not extractable via CLI |
+| `run`     | no  | no | exec-side; admin uses the verb under sudo if needed |
+| `learn`   | no  | no | static documentation |
+| `explain` | no  | no | static documentation |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,7 +1,43 @@
 # shushu testing notes
 
-(Stub — full content lands in Task 28. This page only documents the
-test-isolation conventions wired into the suite today.)
+shushu's test pyramid has three layers:
+
+1. **Unit tests** (`tests/unit/`) — the bulk of coverage; per-module
+   tests for `fs`, `alerts`, `generate`, `users`, `privilege`, `store`,
+   plus per-verb CLI tests. Runs in milliseconds, no privilege
+   required.
+2. **End-to-end self-verify** (`tests/test_self_verify.py`) — a single
+   13-step lifecycle test that walks every verb against a fresh
+   `tmp_path` store. The acceptance gate; a regression here blocks
+   the commit.
+3. **Integration tests** (`tests/integration/`) — exercise real
+   `useradd` / `userdel` and the setuid-fork handoff. Gated behind
+   `SHUSHU_DOCKER=1` and run inside the disposable Docker image at
+   `.github/workflows/Dockerfile.integration`.
+
+Common runner is the `run-tests` skill at
+`.claude/skills/run-tests/scripts/test.sh` (the wrapper that pins
+pytest's basetemp + adds smoke-namespace cleanup).
+
+## How to run the suite
+
+```bash
+# unit + self-verify (skips integration without SHUSHU_DOCKER)
+bash .claude/skills/run-tests/scripts/test.sh -p
+
+# CI parity: parallel + coverage + xml + verbose
+bash .claude/skills/run-tests/scripts/test.sh --ci
+
+# integration only, inside Docker (needs root for useradd)
+docker build -f .github/workflows/Dockerfile.integration -t shushu-int .
+docker run --rm -e SHUSHU_DOCKER=1 shushu-int uv run pytest tests/integration -v
+
+# Coverage report to terminal
+uv run pytest --cov=shushu --cov-report=term
+
+# Single test
+bash .claude/skills/run-tests/scripts/test.sh tests/unit/test_cli_set.py -x
+```
 
 ## Test artifacts live under `/tmp/shushu-tests/`
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,4 +1,151 @@
 # shushu threat model
 
-(Stub — full content lands in Task 28. Until then, see
-`docs/superpowers/specs/2026-04-24-shushu-secrets-cli-design.md` §8.)
+This document expands §8 of the design spec
+([2026-04-24-shushu-secrets-cli-design.md](superpowers/specs/2026-04-24-shushu-secrets-cli-design.md))
+into a full threat-model statement: trust boundary, adversary model,
+risk surfaces, and residual risks.
+
+## Trust boundary
+
+The host OS filesystem and uid model.
+`~/.local/share/shushu/secrets.json` (mode `0600`, owned by the user)
+is protected by exactly the same mechanisms that protect
+`~/.ssh/id_rsa`. shushu adds **no cryptographic layer on top in v1** —
+the H2 "hidden" flag is a CLI contract, not encryption.
+
+The single-admin trusted-host assumption underpins everything.
+Multi-tenant hosts, network services, remote attackers, and
+hardware-level adversaries are out of scope.
+
+## Adversary model (v1)
+
+The threat actor is a **non-root local user with shell access** on the
+same machine. shushu MUST prevent that user from:
+
+1. Reading another user's secrets through shushu.
+2. Writing into another user's store through shushu.
+3. Forging provenance (`source = "admin:*"`).
+4. Extracting another user's plaintext values through any admin verb.
+5. Impersonating another user via ambient resolution.
+
+A user with `sudo` is by definition trusted; their actions are out
+of the v1 threat scope. Root can already read every file on the
+system; shushu cannot meaningfully harden against root.
+
+## Risk surfaces
+
+### 1. setuid-fork handoff
+
+The single chokepoint where uid is changed lives in
+`src/shushu/privilege.py::run_as_user`. Order is:
+
+1. `os.setgroups([])` — drop supplementary groups.
+2. `os.setgid(user.gid)` and `os.setegid(user.gid)`.
+3. `os.setuid(user.uid)` and `os.seteuid(user.uid)`.
+
+Capabilities drop on the `setuid` from euid 0 (no
+`SECBIT_KEEP_CAPS`). All return values are checked by the kernel via
+the syscalls themselves. TOCTOU between `getpwnam` and `setuid` is
+residual on trusted-admin hosts (an admin running `usermod` between
+shushu's lookup and fork is the only way to hit it).
+
+The fork-as-target-user wrapper is in `src/shushu/admin.py::as_user`,
+which:
+
+- Validates the target via `users.resolve(name)` (raises
+  `EXIT_BACKEND` for unknown users).
+- Sets `HOME` in the child after the uid drop so `Path.home()`
+  resolves correctly.
+- Translates ShushuError + `store.*` exceptions inside the child via
+  `cli._translate.translate_errors` so admin failures produce the
+  same structured exit codes as self-mode.
+
+### 2. File-mode drift
+
+Every write goes through `fs.atomic_write_text`, which sets mode
+`0o600` on the temp file before `os.replace`. The store directory is
+created with mode `0o700` by `fs.ensure_store_dir`. Drift is
+detectable via `shushu doctor` (warns on any non-`0o700` dir or
+non-`0o600` file).
+
+### 3. Hidden-secret contract (H2)
+
+CLI contract, not cryptographic. The on-disk file is plaintext at
+`0o600`; a user can `cat ~/.local/share/shushu/secrets.json` and
+read every hidden value. shushu's `hidden=True` flag enforces:
+
+- `get`, `env`, `show` refuse to print the value (exit 64 with
+  remediation pointing at `run --inject`).
+- `generate --hidden` never prints the value to stdout or includes
+  it in `--json` output.
+- `overview` and `list` never expose values regardless of the
+  `hidden` flag.
+- Admin `--user` / `--all-users` paths inherit all of the above —
+  admin can NEVER extract values via the CLI surface, even for root.
+
+The CLI is the contract. Anyone with shell access to the same uid
+can read the plaintext. v2 will add real at-rest encryption — see
+the residual-risks table below.
+
+### 4. Admin metadata exfiltration
+
+`overview --all-users` reveals secret **names**, **sources**,
+**purposes**, **rotation_howto**, **alert_at**, **handed_over_by**,
+and **timestamps** — deliberately, for audit. Values are never
+included.
+
+Naming discipline (don't put secrets in name) is outside shushu's
+scope. The convention documented in `docs/rubric-mapping.md` and
+`shushu explain` is to use env-var-style identifiers.
+
+### 5. Command-line argument leakage
+
+`shushu set FOO bar` writes the literal value `bar` into the
+process command line, which is visible in `/proc/<pid>/cmdline` and
+in shell history. The recommended form is:
+
+```bash
+shushu set FOO -    # read value from stdin
+```
+
+`shushu set` documents this in `--help` and the canonical example
+in the README leads with the stdin form.
+
+`shushu run --inject VAR=NAME -- cmd` takes only the secret **name**
+on the command line; the value is read from the store inside shushu
+and stamped into the child's env, never on the command line.
+
+### 6. Input validation
+
+- Names are validated against `^[A-Z][A-Z0-9_]*$` in
+  `store._validate_name`. Lowercase, dashes, dots, etc. are rejected
+  (env-var-unsafe forms).
+- `shushu env` single-quotes values and escapes embedded `'` as
+  `'\''` (POSIX-safe). Round-trip through `bash -c` is asserted by
+  `test_env_escapes_single_quotes_posix_safe`.
+- `shushu run --inject VAR=NAME` parses only `VAR=NAME` shape;
+  malformed specs (missing `=`, empty VAR, empty NAME) raise explicit
+  per-case `EXIT_USER_ERROR`.
+
+## Residual risks (documented, not mitigated in v1)
+
+| Risk | Mitigation status |
+|---|---|
+| Plaintext at rest in `secrets.json` | Tracked as the encryption-at-rest issue (see below); v2 candidate. |
+| Root can `cat` any user's secrets directly | CLI surface doesn't expose values via admin verbs; accepted (root is by definition trusted). |
+| Orphan stores after user deletion | `doctor --all-users` enumerates orphan stores; cleanup verb deferred to v2. |
+| setuid-fork TOCTOU with concurrent `usermod` | Accepted on trusted-admin host. |
+| Shell-history leakage of literal `set NAME value` | Stdin form (`set NAME -`) is the documented preferred shape; covered in `shushu explain set`. |
+
+## Encryption-at-rest tracking issue
+
+shushu v1 deliberately ships without on-disk encryption. The full
+rationale + v2 candidate approaches (age, libsecret, pass/gpg) are
+captured in the tracking issue:
+
+<!-- TODO: replace with real issue URL after Task 29 step 1 -->
+**Issue:** [v2: encryption at rest for secret values](https://github.com/agentculture/shushu/issues/new)
+
+The threat-model assertion that "values are not encrypted at rest"
+is a deliberate v1 choice, not an oversight. v2 will add real
+at-rest encryption with a `schema_version = 2` migration.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -117,9 +117,10 @@ and stamped into the child's env, never on the command line.
 
 ### 6. Input validation
 
-- Names are validated against `^[A-Z][A-Z0-9_]*$` in
-  `store._validate_name`. Lowercase, dashes, dots, etc. are rejected
-  (env-var-unsafe forms).
+- Names are validated against `^[A-Z_][A-Z0-9_]{0,63}$` in
+  `store._validate_name` (compiled as `store.NAME_RE`). Lowercase,
+  dashes, dots, and names longer than 64 characters are rejected
+  (env-var-unsafe forms); leading `_` is allowed.
 - `shushu env` single-quotes values and escapes embedded `'` as
   `'\''` (POSIX-safe). Round-trip through `bash -c` is asserted by
   `test_env_escapes_single_quotes_posix_safe`.
@@ -133,7 +134,7 @@ and stamped into the child's env, never on the command line.
 |---|---|
 | Plaintext at rest in `secrets.json` | Tracked as the encryption-at-rest issue (see below); v1.x candidate. |
 | Root can `cat` any user's secrets directly | CLI surface doesn't expose values via admin verbs; accepted (root is by definition trusted). |
-| Orphan stores after user deletion | `doctor --all-users` enumerates orphan stores; cleanup verb deferred to a future v1.x release. |
+| Orphan stores after user deletion | Not detected in 0.x. `doctor --all-users` enumerates `users.all_users()`, so a store left on disk after the OS user is deleted is invisible. Filesystem-scan-based detection + a cleanup verb deferred to a future v1.x release. |
 | setuid-fork TOCTOU with concurrent `usermod` | Accepted on trusted-admin host. |
 | Shell-history leakage of literal `set NAME value` | Stdin form (`set NAME -`) is the documented preferred shape; covered in `shushu explain set`. |
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -84,8 +84,8 @@ read every hidden value. shushu's `hidden=True` flag enforces:
   admin can NEVER extract values via the CLI surface, even for root.
 
 The CLI is the contract. Anyone with shell access to the same uid
-can read the plaintext. v2 will add real at-rest encryption — see
-the residual-risks table below.
+can read the plaintext. A future v1.x release will add real at-rest
+encryption — see the residual-risks table below.
 
 ### 4. Admin metadata exfiltration
 
@@ -131,21 +131,21 @@ and stamped into the child's env, never on the command line.
 
 | Risk | Mitigation status |
 |---|---|
-| Plaintext at rest in `secrets.json` | Tracked as the encryption-at-rest issue (see below); v2 candidate. |
+| Plaintext at rest in `secrets.json` | Tracked as the encryption-at-rest issue (see below); v1.x candidate. |
 | Root can `cat` any user's secrets directly | CLI surface doesn't expose values via admin verbs; accepted (root is by definition trusted). |
-| Orphan stores after user deletion | `doctor --all-users` enumerates orphan stores; cleanup verb deferred to v2. |
+| Orphan stores after user deletion | `doctor --all-users` enumerates orphan stores; cleanup verb deferred to a future v1.x release. |
 | setuid-fork TOCTOU with concurrent `usermod` | Accepted on trusted-admin host. |
 | Shell-history leakage of literal `set NAME value` | Stdin form (`set NAME -`) is the documented preferred shape; covered in `shushu explain set`. |
 
 ## Encryption-at-rest tracking issue
 
-shushu v1 deliberately ships without on-disk encryption. The full
-rationale + v2 candidate approaches (age, libsecret, pass/gpg) are
-captured in the tracking issue:
+The current 0.x line deliberately ships without on-disk encryption.
+The full rationale + candidate approaches (age, libsecret, pass/gpg)
+are captured in the tracking issue:
 
-<!-- TODO: replace with real issue URL after Task 29 step 1 -->
-**Issue:** [v2: encryption at rest for secret values](https://github.com/agentculture/shushu/issues/new)
+**Issue:** [#8 — v1.x: encryption at rest for secret values](https://github.com/agentculture/shushu/issues/8)
 
 The threat-model assertion that "values are not encrypted at rest"
-is a deliberate v1 choice, not an oversight. v2 will add real
-at-rest encryption with a `schema_version = 2` migration.
+is a deliberate 0.x choice, not an oversight. A future v1.x release
+will add real at-rest encryption with a `schema_version = 2`
+migration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shushu"
-version = "0.7.0"
+version = "0.8.0"
 description = "shushu CLI"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_self_verify.py
+++ b/tests/test_self_verify.py
@@ -1,0 +1,117 @@
+"""End-to-end dogfood lifecycle.
+
+Single test that walks every verb against a fresh `tmp_path` store,
+asserting the H2 hidden-secret contract holds end-to-end (hidden values
+never appear in stdout/stderr from any verb except `run --inject`).
+Every regression here blocks the commit.
+
+Uses the shared `cli_run` fixture and autouse `_tmp_home` from
+`tests/conftest.py` (added in PR #6's review-fix). The single
+subprocess invocation in step 8 is necessary because `os.execvpe`
+inside `cli_run` would replace the pytest process itself.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess  # noqa: S404
+import sys
+
+
+def test_self_verify_lifecycle(cli_run):
+    # 1. set with --alert-at
+    rc, _, _ = cli_run(["set", "FOO", "bar", "--purpose", "self-test", "--alert-at", "2099-01-01"])
+    assert rc == 0
+
+    # 2. generate hidden — value must NOT appear in stdout
+    rc, out_gen, _ = cli_run(["generate", "BAZ", "--bytes", "16", "--hidden"])
+    assert rc == 0
+    assert "BAZ" in out_gen
+    # Verify the literal random value never leaked. Read it from the store
+    # directly (legitimate test introspection) and assert it isn't in stdout.
+    from shushu import store
+
+    rec = store.get_record("BAZ")
+    assert rec.value not in out_gen
+    assert rec.hidden is True
+
+    # 3. list — both names sorted
+    rc, out, _ = cli_run(["list", "--json"])
+    assert rc == 0
+    assert set(json.loads(out)["names"]) == {"FOO", "BAZ"}
+
+    # 4. show — metadata only, never `value`
+    rc, out, _ = cli_run(["show", "FOO", "--json"])
+    assert rc == 0
+    payload = json.loads(out)
+    assert "value" not in payload
+    assert payload["name"] == "FOO"
+
+    # 5. get — visible secret
+    rc, out, _ = cli_run(["get", "FOO"])
+    assert rc == 0
+    assert out.strip() == "bar"
+
+    # 6. get hidden — refused with EXIT_USER_ERROR
+    rc, _, err = cli_run(["get", "BAZ"])
+    assert rc == 64
+    assert "hidden" in err.lower()
+
+    # 7. env — POSIX-quoted export for visible
+    rc, out, _ = cli_run(["env", "FOO"])
+    assert rc == 0
+    assert "export FOO='bar'" in out
+
+    # 8. run --inject — only consumer for hidden secrets. subprocess because
+    # os.execvpe inside the in-process cli_run would replace pytest.
+    r = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "shushu",
+            "run",
+            "--inject",
+            "X=BAZ",
+            "--",
+            sys.executable,
+            "-c",
+            "import os; print(len(os.environ['X']))",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "SHUSHU_HOME": os.environ["SHUSHU_HOME"]},
+    )
+    assert r.returncode == 0, r.stderr
+    # 16 bytes of hex = 32 chars.
+    assert r.stdout.strip() == "32"
+
+    # 9. metadata-only set — value preserved
+    rc, _, _ = cli_run(["set", "FOO", "--purpose", "updated"])
+    assert rc == 0
+    assert store.get_record("FOO").purpose == "updated"
+    assert store.get_value("FOO") == "bar"  # value unchanged
+
+    # 10. immutable refusal — source change rejected
+    rc, _, _ = cli_run(["set", "FOO", "v2", "--source", "https://other"])
+    assert rc == 64
+
+    # 11. delete
+    rc, _, _ = cli_run(["delete", "FOO"])
+    assert rc == 0
+
+    # 12. doctor — passes on remaining hidden record
+    rc, out, _ = cli_run(["doctor", "--json"])
+    assert rc == 0
+    assert json.loads(out)["ok"] is True
+
+    # 13. overview — 1 secret remaining (BAZ)
+    rc, out, _ = cli_run(["overview", "--json"])
+    assert rc == 0
+    payload = json.loads(out)
+    assert len(payload["secrets"]) == 1
+    assert payload["secrets"][0]["name"] == "BAZ"
+    assert payload["secrets"][0]["hidden"] is True
+    # Hidden contract holds end-to-end: no value field anywhere in overview.
+    assert "value" not in payload["secrets"][0]

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "shushu"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

The **last PR of the spec-complete cycle on the 0.x line**. After this
lands, every verb in the design spec runs end-to-end (self-mode and
admin-mode), the test pyramid has full unit + lifecycle + integration
coverage, and the docs are production-shape.

| Task | What landed |
|---|---|
| 27 | `tests/test_self_verify.py` — single 13-step end-to-end lifecycle test that walks every verb against a fresh `tmp_path` store, asserting the H2 hidden contract holds across set / generate / show / get / env / run / list / delete / doctor / overview / metadata-only update / immutable refusal. Acceptance gate. |
| 28 | `README.md` rewrite, `CLAUDE.md` rewrite, `docs/threat-model.md` (full from spec §8), `docs/rubric-mapping.md` (per-verb purpose / exit codes / JSON shape), `docs/testing.md` (test-pyramid section). +712 LOC of docs across 5 files. |
| 29 | Version bump `0.7.0 → 0.8.0`. CHANGELOG `[0.8.0]` entry. Encryption-at-rest tracking issue ([#8](https://github.com/agentculture/shushu/issues/8)) filed and linked from the threat-model + README + CHANGELOG. |

## Version naming convention (clarified during this PR)

- **0.x** — current line. Pre-stable, no API-stability promise. shushu
  v0.8.0 covers every verb in the v1 design spec, but ships **without
  on-disk encryption** (the H2 "hidden" flag is a CLI contract, not
  cryptography).
- **v1.x** — future line. Adds real at-rest encryption with a
  `schema_version = 2` migration. Tracked at
  [#8](https://github.com/agentculture/shushu/issues/8).

## Test plan

- [x] `bash .claude/skills/run-tests/scripts/test.sh -p` — 115 unit + 1 lifecycle pass; 13 integration skipped (correctly gated)
- [x] `docker run --rm -e SHUSHU_DOCKER=1 shushu-int uv run pytest tests/integration -v` — 13/13 pass
- [x] `uv run black --check src/shushu tests` — clean
- [x] `uv run isort --check-only src/shushu tests` — clean
- [x] `uv run flake8 src/shushu tests` — clean
- [x] `uv run bandit -r src/shushu -c pyproject.toml` — clean
- [x] `uv run pylint --errors-only src/shushu` — clean
- [x] `scripts/lint-md.sh` — 0 errors across 10 files
- [x] `uv run shushu --version` → `shushu 0.8.0`
- [x] Smoke: `shushu learn`, `shushu explain hidden` end-to-end OK
- [ ] CI green on PR head

## Pushback notes

- **qodo `__version__`** → standard PUSHBACK (recurring across PR #2 / #3 / #4 / #5 / #6 / #7).
- **SonarCloud `docker:S6471`** (Dockerfile USER root) → standard PUSHBACK with the same rationale as PR #7. Mark REVIEWED/SAFE in SonarCloud UI after merge.

## After this lands

- Mark `docker:S6471` REVIEWED/SAFE on SonarCloud.
- Future work goes to issue #8 (v1.x: at-rest encryption) and any
  small 0.x-line maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude